### PR TITLE
Add support for modified buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,3 +490,14 @@ for line_number in range(start, end)
   let index += 1
 endfor
 ```
+
+### Unsaved files
+
+Editors can supply `gomodifytags` with the contents of unsaved buffers by
+using the `-modified` flag and writing an archive to stdin.  
+Files in the archive will be preferred over those on disk.
+
+Each archive entry consists of:
+ - the file name, followed by a newline
+ - the (decimal) file size, followed by a newline
+ - the contents of the file

--- a/main.go
+++ b/main.go
@@ -182,9 +182,11 @@ func (c *config) rewrite() (ast.Node, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse -modified archive: %v", err)
 		}
-		if fc, ok := archive[c.file]; ok {
-			contents = fc
+		fc, ok := archive[c.file]
+		if !ok {
+			return nil, fmt.Errorf("couldn't find %s in archive", c.file)
 		}
+		contents = fc
 	}
 	node, err := parser.ParseFile(c.fset, c.file, contents, parser.ParseComments)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -323,3 +323,26 @@ type foo struct {
 		t.Errorf("got:\n====\n%s\nwant:\n====\n%s\n", got, want)
 	}
 }
+
+func TestModifiedFileMissing(t *testing.T) {
+	cfg := &config{
+		add:        []string{"json"},
+		output:     "source",
+		structName: "foo",
+		transform:  "snakecase",
+		file:       "struct_add_modified",
+		modified: strings.NewReader(`file_that_doesnt_exist
+55
+package foo
+
+type foo struct {
+	bar string
+	t   bool
+}
+`),
+	}
+	_, err := cfg.rewrite()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -205,7 +206,12 @@ func TestRewrite(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			from, err := ioutil.ReadFile(ts.cfg.file)
+			var from []byte
+			if ts.cfg.modified != nil {
+				from, err = ioutil.ReadAll(ts.cfg.modified)
+			} else {
+				from, err = ioutil.ReadFile(ts.cfg.file)
+			}
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -276,5 +282,44 @@ func TestJSON(t *testing.T) {
 					ts.file, got, want, from)
 			}
 		})
+	}
+}
+
+func TestModifiedRewrite(t *testing.T) {
+	cfg := &config{
+		add:        []string{"json"},
+		output:     "source",
+		structName: "foo",
+		transform:  "snakecase",
+		file:       "struct_add_modified",
+		modified: strings.NewReader(`struct_add_modified
+55
+package foo
+
+type foo struct {
+	bar string
+	t   bool
+}
+`),
+	}
+	node, err := cfg.rewrite()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := cfg.format(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden := filepath.Join(fixtureDir, "struct_add.golden")
+	want, err := ioutil.ReadFile(golden)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// compare
+	if !bytes.Equal([]byte(got), want) {
+		t.Errorf("got:\n====\n%s\nwant:\n====\n%s\n", got, want)
 	}
 }


### PR DESCRIPTION
Modified files can be read from stdin using the same archive format as the guru and gogetdoc tools.

Fixes #1