### PR TITLE
improve line selection to be more flexible

### DIFF
--- a/main.go
+++ b/main.go
@@ -514,22 +514,6 @@ func (c *config) lineSelection(file ast.Node) (ast.Node, error) {
 		return nil, errors.New("wrong range. start line cannot be larger than end line")
 	}
 
-	structs := collectStructs(file)
-
-	var encStruct *ast.StructType
-	for _, st := range structs {
-		structBegin := c.fset.Position(st.node.Pos()).Line
-		structEnd := c.fset.Position(st.node.End()).Line
-
-		if structBegin <= c.start && c.end <= structEnd {
-			encStruct = st.node
-		}
-	}
-
-	if encStruct == nil {
-		return nil, errors.New("selection is not inside a struct")
-	}
-
 	return c.rewriteFields(file)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -72,6 +72,42 @@ func TestRewrite(t *testing.T) {
 			},
 		},
 		{
+			file: "line_add_outside",
+			cfg: &config{
+				add:       []string{"json"},
+				output:    "source",
+				line:      "2,8",
+				transform: "snakecase",
+			},
+		},
+		{
+			file: "line_add_outside_partial_start",
+			cfg: &config{
+				add:       []string{"json"},
+				output:    "source",
+				line:      "2,5",
+				transform: "snakecase",
+			},
+		},
+		{
+			file: "line_add_outside_partial_end",
+			cfg: &config{
+				add:       []string{"json"},
+				output:    "source",
+				line:      "5,8",
+				transform: "snakecase",
+			},
+		},
+		{
+			file: "line_add_intersect_partial",
+			cfg: &config{
+				add:       []string{"json"},
+				output:    "source",
+				line:      "5,11",
+				transform: "snakecase",
+			},
+		},
+		{
 			file: "line_add_comment",
 			cfg: &config{
 				add:       []string{"json"},

--- a/test-fixtures/line_add_intersect_partial.golden
+++ b/test-fixtures/line_add_intersect_partial.golden
@@ -1,0 +1,13 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool `json:"t"`
+	qux int  `json:"qux"`
+}
+
+type bar struct {
+	foo string `json:"foo"`
+	s   bool   `json:"s"`
+	mut int
+}

--- a/test-fixtures/line_add_intersect_partial.input
+++ b/test-fixtures/line_add_intersect_partial.input
@@ -1,0 +1,14 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool
+	qux int
+}
+
+type bar struct {
+	foo string
+	s   bool
+	mut int
+}
+

--- a/test-fixtures/line_add_outside.golden
+++ b/test-fixtures/line_add_outside.golden
@@ -1,0 +1,7 @@
+package foo
+
+type foo struct {
+	bar string `json:"bar"`
+	t   bool   `json:"t"`
+	qux int    `json:"qux"`
+}

--- a/test-fixtures/line_add_outside.input
+++ b/test-fixtures/line_add_outside.input
@@ -1,0 +1,8 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool
+	qux int
+}
+

--- a/test-fixtures/line_add_outside_partial_end.golden
+++ b/test-fixtures/line_add_outside_partial_end.golden
@@ -1,0 +1,7 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool `json:"t"`
+	qux int  `json:"qux"`
+}

--- a/test-fixtures/line_add_outside_partial_end.input
+++ b/test-fixtures/line_add_outside_partial_end.input
@@ -1,0 +1,8 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool
+	qux int
+}
+

--- a/test-fixtures/line_add_outside_partial_start.golden
+++ b/test-fixtures/line_add_outside_partial_start.golden
@@ -1,0 +1,7 @@
+package foo
+
+type foo struct {
+	bar string `json:"bar"`
+	t   bool   `json:"t"`
+	qux int
+}

--- a/test-fixtures/line_add_outside_partial_start.input
+++ b/test-fixtures/line_add_outside_partial_start.input
@@ -1,0 +1,8 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool
+	qux int
+}
+


### PR DESCRIPTION
This PR makes selecting structs for the `-line` mode flexible. We don't
have to be strict now. If the selection contains any kind of struct,
it'll work. So one selection part can be outside the struct, however if
the other part overlaps any struct selection it's still valid.

This is a backwards compatible change. It improves the overall user
experience and makes it easier for people using with editors.