### PR TITLE
Continue to process tags in case of malformed fields

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -249,6 +249,15 @@ func TestRewrite(t *testing.T) {
 				transform: "snakecase",
 			},
 		},
+		{
+			file: "errors",
+			cfg: &config{
+				add:       []string{"json"},
+				output:    "source",
+				line:      "4,7",
+				transform: "snakecase",
+			},
+		},
 	}
 
 	for _, ts := range test {
@@ -267,10 +276,12 @@ func TestRewrite(t *testing.T) {
 
 			rewrittenNode, err := ts.cfg.rewrite(node, start, end)
 			if err != nil {
-				t.Fatal(err)
+				if _, ok := err.(*rewriteErrors); !ok {
+					t.Fatal(err)
+				}
 			}
 
-			out, err := ts.cfg.format(rewrittenNode)
+			out, err := ts.cfg.format(rewrittenNode, err)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -346,6 +357,13 @@ func TestJSON(t *testing.T) {
 			},
 			err: errors.New("line selection is invalid"),
 		},
+		{
+			file: "json_errors",
+			cfg: &config{
+				add:  []string{"json"},
+				line: "4,7",
+			},
+		},
 	}
 
 	for _, ts := range test {
@@ -368,10 +386,12 @@ func TestJSON(t *testing.T) {
 
 			rewrittenNode, err := ts.cfg.rewrite(node, start, end)
 			if err != nil {
-				t.Fatal(err)
+				if _, ok := err.(*rewriteErrors); !ok {
+					t.Fatal(err)
+				}
 			}
 
-			out, err := ts.cfg.format(rewrittenNode)
+			out, err := ts.cfg.format(rewrittenNode, err)
 			if !reflect.DeepEqual(err, ts.err) {
 				t.Logf("want: %v", ts.err)
 				t.Logf("got: %v", err)
@@ -447,7 +467,7 @@ type foo struct {
 		t.Fatal(err)
 	}
 
-	got, err := cfg.format(rewrittenNode)
+	got, err := cfg.format(rewrittenNode, err)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test-fixtures/errors.golden
+++ b/test-fixtures/errors.golden
@@ -1,0 +1,8 @@
+package foo
+
+type foo struct {
+	bar string   `json:"bar"`
+	t   bool     `json:"malformed`
+	a   []string `json:"a"`
+	b   bool     `json:"b"`
+}

--- a/test-fixtures/errors.input
+++ b/test-fixtures/errors.input
@@ -1,0 +1,8 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool `json:"malformed`
+	a   []string
+	b   bool
+}

--- a/test-fixtures/json_errors.golden
+++ b/test-fixtures/json_errors.golden
@@ -1,0 +1,13 @@
+{
+  "start": 4,
+  "end": 7,
+  "lines": [
+    "\tbar string   `json:\"bar\"`",
+    "\tt   bool     `json`",
+    "\ta   []string `json:\"a\"`",
+    "\tb   bool     `json:\"b\"`"
+  ],
+  "errors": [
+    "test-fixtures/json_errors.input:5:2:bad syntax for struct tag pair"
+  ]
+}

--- a/test-fixtures/json_errors.input
+++ b/test-fixtures/json_errors.input
@@ -1,0 +1,8 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool `json`
+	a   []string
+	b   bool 
+}


### PR DESCRIPTION
Be sure we continue  to process the other fields if there is a malformed field. This fixes the case when a field was malformed and gomodifytags would stop continue to process other fields.

In addition, if the user opts for a `json` format, we return an array of errors  which fields are malformed.

/cc @ramya-rao-a @zmb3 @davidrjenni 
This change now return a list of errors if it can't parse when it outputs in `json` format mode:

```
$ cat demo.go
package main

type Foo struct {
	Example string
	Bar     bool `json:"bar`
	Foo     []string
}
$ gomodifytags -file demo.go -struct Foo -add-tags json -format json
{
  "start": 3,
  "end": 7,
  "lines": [
    "type Foo struct {",
    "\tExample string   `json:\"example\"`",
    "\tBar     bool     `json:\"bar`",
    "\tFoo     []string `json:\"foo\"`",
    "}"
  ],
  "errors": [
    "demo.go:5:2:bad syntax for struct tag value"
  ]
}
```

The `errors` field is new. For example `vim-go` still process the file, but now also displays the list of errors if any. If you have already automatic `go vet` you don't need to show the error as it takes care of it.

It's a backwards compatible change and it's up to you if you want to read the errors array or not.

fixes #19 
