### PR TITLE
Add new "keep" tranform option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ We currently support the following transformations:
 * `camelcase`: `"BaseDomain"` -> `"baseDomain"`
 * `lispcase`:  `"BaseDomain"` -> `"base-domain"`
 * `pascalcase`:  `"BaseDomain"` -> `"BaseDomain"`
+* `keep`:  keeps the original field name
 
 You can also pass a static value for each fields. This is useful if you use Go
 packages that validates the struct fields or extract values for certain

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func realMain() error {
 		flagOverride  = flag.Bool("override", false, "Override current tags when adding tags")
 		flagTransform = flag.String("transform", "snakecase",
 			"Transform adds a transform rule when adding tags."+
-				" Current options: [snakecase, camelcase, lispcase, pascalcase]")
+				" Current options: [snakecase, camelcase, lispcase, pascalcase, keep]")
 		flagSort = flag.Bool("sort", false,
 			"Sort sorts the tags in increasing order according to the key name")
 
@@ -380,6 +380,8 @@ func (c *config) addTags(fieldName string, tags *structtag.Tags) (*structtag.Tag
 		}
 
 		name = strings.Join(titled, "")
+	case "keep":
+		name = fieldName
 	default:
 		unknown = true
 	}


### PR DESCRIPTION
This new transform option does not change the field name. Instead it
reuses the field name for the struct tag. Supersedes #40