### PR TITLE
Fixes Windows specific invalid line directive issue.

### DIFF
--- a/main.go
+++ b/main.go
@@ -508,10 +508,21 @@ func (c *config) format(file ast.Node, rwErrs error) (string, error) {
 			}
 
 			splitted := strings.Split(txt, ":")
-			if len(splitted) != 2 {
+			splittedCnt := len(splitted)
+			// MacOS n Linux based systems would get line directives as follows
+			// `//line /file/path/to/file.go:linenumber`
+			// whereas Windows based systems would get line directives as follows
+			// `//line c:\\file\\path\\to\\file.go:linenumber`
+			if splittedCnt != 2 && splittedCnt != 3 {
 				return "", fmt.Errorf("invalid line directive found: %q", txt)
 			}
-			lineNr, err := strconv.Atoi(splitted[1])
+			var lineNr int
+			var err error
+			if splittedCnt == 2 {
+				lineNr, err = strconv.Atoi(splitted[1])
+			} else { // splittedCnt == 3, for Windows file paths
+				lineNr, err = strconv.Atoi(splitted[2])
+			}
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
I believe the reason for this error is the presence of a colon `:` in a Windows path.
https://github.com/fatih/gomodifytags/blob/master/main.go#L510-L513
In the above linked lines, when you try to split by `:` it fails since you expect `//line file-path:line-number`, but in Windows you get 3 `//line d:\\Projects\\github.com\\shyamsalimkumar\\scratch-space\\main.go:1` ie `drive:path:linenumber`

Fixes #45 