### PR TITLE
Add new "skip-private" option

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/fatih/camelcase"
 	"github.com/fatih/structtag"
@@ -56,9 +57,10 @@ type config struct {
 	remove        []string
 	removeOptions []string
 
-	add        []string
-	addOptions []string
-	override   bool
+	add               []string
+	addOptions        []string
+	override          bool
+	skipPrivateFields bool
 
 	transform   string
 	sort        bool
@@ -99,8 +101,9 @@ func realMain() error {
 		flagAddTags = flag.String("add-tags", "",
 			"Adds tags for the comma separated list of keys."+
 				"Keys can contain a static value, i,e: json:foo")
-		flagOverride  = flag.Bool("override", false, "Override current tags when adding tags")
-		flagTransform = flag.String("transform", "snakecase",
+		flagOverride          = flag.Bool("override", false, "Override current tags when adding tags")
+		flagSkipPrivateFields = flag.Bool("skip-private", false, "Skip private fields")
+		flagTransform         = flag.String("transform", "snakecase",
 			"Transform adds a transform rule when adding tags."+
 				" Current options: [snakecase, camelcase, lispcase, pascalcase, keep]")
 		flagSort = flag.Bool("sort", false,
@@ -127,17 +130,18 @@ func realMain() error {
 	}
 
 	cfg := &config{
-		file:        *flagFile,
-		line:        *flagLine,
-		structName:  *flagStruct,
-		offset:      *flagOffset,
-		output:      *flagOutput,
-		write:       *flagWrite,
-		clear:       *flagClearTags,
-		clearOption: *flagClearOptions,
-		transform:   *flagTransform,
-		sort:        *flagSort,
-		override:    *flagOverride,
+		file:              *flagFile,
+		line:              *flagLine,
+		structName:        *flagStruct,
+		offset:            *flagOffset,
+		output:            *flagOutput,
+		write:             *flagWrite,
+		clear:             *flagClearTags,
+		clearOption:       *flagClearOptions,
+		transform:         *flagTransform,
+		sort:              *flagSort,
+		override:          *flagOverride,
+		skipPrivateFields: *flagSkipPrivateFields,
 	}
 
 	if *flagModified {
@@ -617,13 +621,25 @@ func (c *config) rewrite(node ast.Node, start, end int) (ast.Node, error) {
 				continue
 			}
 
-			if f.Tag == nil {
-				f.Tag = &ast.BasicLit{}
-			}
-
 			fieldName := ""
 			if len(f.Names) != 0 {
-				fieldName = f.Names[0].Name
+				if c.skipPrivateFields {
+				publicFieldSearch:
+					for _, field := range f.Names {
+						for _, c := range field.Name {
+							if unicode.IsUpper(c) {
+								fieldName = field.Name
+								break publicFieldSearch
+							}
+							break
+						}
+					}
+					if fieldName == "" {
+						continue
+					}
+				} else {
+					fieldName = f.Names[0].Name
+				}
 			}
 
 			// anonymous field
@@ -634,6 +650,10 @@ func (c *config) rewrite(node ast.Node, start, end int) (ast.Node, error) {
 				}
 
 				fieldName = ident.Name
+			}
+
+			if f.Tag == nil {
+				f.Tag = &ast.BasicLit{}
 			}
 
 			res, err := c.process(fieldName, f.Tag.Value)

--- a/main.go
+++ b/main.go
@@ -603,6 +603,16 @@ func (c *config) offsetSelection(file ast.Node) (int, int, error) {
 	return start, end, nil
 }
 
+func isPublicName(name string) bool {
+	for _, c := range name {
+		if unicode.IsUpper(c) {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
 // rewrite rewrites the node for structs between the start and end
 // positions
 func (c *config) rewrite(node ast.Node, start, end int) (ast.Node, error) {
@@ -623,22 +633,16 @@ func (c *config) rewrite(node ast.Node, start, end int) (ast.Node, error) {
 
 			fieldName := ""
 			if len(f.Names) != 0 {
-				if c.skipPrivateFields {
-				publicFieldSearch:
-					for _, field := range f.Names {
-						for _, c := range field.Name {
-							if unicode.IsUpper(c) {
-								fieldName = field.Name
-								break publicFieldSearch
-							}
-							break
-						}
+				for _, field := range f.Names {
+					if !c.skipPrivateFields || isPublicName(field.Name) {
+						fieldName = field.Name
+						break
 					}
-					if fieldName == "" {
-						continue
-					}
-				} else {
-					fieldName = f.Names[0].Name
+				}
+
+				// nothing to process, continue with next line
+				if fieldName == "" {
+					continue
 				}
 			}
 

--- a/main.go
+++ b/main.go
@@ -605,10 +605,7 @@ func (c *config) offsetSelection(file ast.Node) (int, int, error) {
 
 func isPublicName(name string) bool {
 	for _, c := range name {
-		if unicode.IsUpper(c) {
-			return true
-		}
-		return false
+		return unicode.IsUpper(c)
 	}
 	return false
 }

--- a/main_test.go
+++ b/main_test.go
@@ -313,6 +313,26 @@ func TestRewrite(t *testing.T) {
 				transform: "snakecase",
 			},
 		},
+		{
+			file: "skip_private",
+			cfg: &config{
+				add:               []string{"json"},
+				output:            "source",
+				structName:        "foo",
+				transform:         "snakecase",
+				skipPrivateFields: true,
+			},
+		},
+		{
+			file: "skip_private_multiple_names",
+			cfg: &config{
+				add:               []string{"json"},
+				output:            "source",
+				structName:        "foo",
+				transform:         "snakecase",
+				skipPrivateFields: true,
+			},
+		},
 	}
 
 	for _, ts := range test {

--- a/test-fixtures/skip_private.golden
+++ b/test-fixtures/skip_private.golden
@@ -1,0 +1,6 @@
+package foo
+
+type foo struct {
+	Bar string `json:"bar"`
+	t   bool
+}

--- a/test-fixtures/skip_private.input
+++ b/test-fixtures/skip_private.input
@@ -1,0 +1,6 @@
+package foo
+
+type foo struct {
+	Bar string
+	t   bool
+}

--- a/test-fixtures/skip_private_multiple_names.golden
+++ b/test-fixtures/skip_private_multiple_names.golden
@@ -1,0 +1,6 @@
+package foo
+
+type foo struct {
+	Bar    string `json:"bar"`
+	t, Baz bool   `json:"baz"`
+}

--- a/test-fixtures/skip_private_multiple_names.input
+++ b/test-fixtures/skip_private_multiple_names.input
@@ -1,0 +1,6 @@
+package foo
+
+type foo struct {
+	Bar    string
+	t, Baz bool
+}


### PR DESCRIPTION
Really we never need JSON tags for private fields
So this is such an option

For example you may have following struct

    type Struct struct {
        Public  int
        private int
    }

Currently gomodifytags would add these tags

    type Struct struct {
        Public  int `json:"public"`
        private int `json:"private"`
    }

With new option it would add

    type Struct struct {
        Public  int `json:"public"`
        private int
    }