### PR TITLE
rename --skip-private to --skip-unexported

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,15 +202,15 @@ type Server struct {
 If the key already exists you don't have to use `-add-tags`
 
 
-### Skipping private fields
+### Skipping unexported fields
 
 By default all fields are processed. This main reason for this is to allow
 structs to evolve with time and be ready in case a field is exported in the
 future. However if you don't like this behavior, you can skip it by passing the
-`--skip-private` flag:
+`--skip-unexported` flag:
 
 ```
-$ gomodifytags -file demo.go -struct Server -add-tags json --skip-private
+$ gomodifytags -file demo.go -struct Server -add-tags json --skip-unexported
 ```
 ```go
 package main

--- a/main.go
+++ b/main.go
@@ -57,10 +57,10 @@ type config struct {
 	remove        []string
 	removeOptions []string
 
-	add               []string
-	addOptions        []string
-	override          bool
-	skipPrivateFields bool
+	add                  []string
+	addOptions           []string
+	override             bool
+	skipUnexportedFields bool
 
 	transform   string
 	sort        bool
@@ -102,7 +102,7 @@ func realMain() error {
 			"Adds tags for the comma separated list of keys."+
 				"Keys can contain a static value, i,e: json:foo")
 		flagOverride          = flag.Bool("override", false, "Override current tags when adding tags")
-		flagSkipPrivateFields = flag.Bool("skip-private", false, "Skip private fields")
+		flagSkipPrivateFields = flag.Bool("skip-unexported", false, "Skip unexported fields")
 		flagTransform         = flag.String("transform", "snakecase",
 			"Transform adds a transform rule when adding tags."+
 				" Current options: [snakecase, camelcase, lispcase, pascalcase, keep]")
@@ -130,18 +130,18 @@ func realMain() error {
 	}
 
 	cfg := &config{
-		file:              *flagFile,
-		line:              *flagLine,
-		structName:        *flagStruct,
-		offset:            *flagOffset,
-		output:            *flagOutput,
-		write:             *flagWrite,
-		clear:             *flagClearTags,
-		clearOption:       *flagClearOptions,
-		transform:         *flagTransform,
-		sort:              *flagSort,
-		override:          *flagOverride,
-		skipPrivateFields: *flagSkipPrivateFields,
+		file:                 *flagFile,
+		line:                 *flagLine,
+		structName:           *flagStruct,
+		offset:               *flagOffset,
+		output:               *flagOutput,
+		write:                *flagWrite,
+		clear:                *flagClearTags,
+		clearOption:          *flagClearOptions,
+		transform:            *flagTransform,
+		sort:                 *flagSort,
+		override:             *flagOverride,
+		skipUnexportedFields: *flagSkipPrivateFields,
 	}
 
 	if *flagModified {
@@ -631,7 +631,7 @@ func (c *config) rewrite(node ast.Node, start, end int) (ast.Node, error) {
 			fieldName := ""
 			if len(f.Names) != 0 {
 				for _, field := range f.Names {
-					if !c.skipPrivateFields || isPublicName(field.Name) {
+					if !c.skipUnexportedFields || isPublicName(field.Name) {
 						fieldName = field.Name
 						break
 					}

--- a/main_test.go
+++ b/main_test.go
@@ -316,21 +316,21 @@ func TestRewrite(t *testing.T) {
 		{
 			file: "skip_private",
 			cfg: &config{
-				add:               []string{"json"},
-				output:            "source",
-				structName:        "foo",
-				transform:         "snakecase",
-				skipPrivateFields: true,
+				add:                  []string{"json"},
+				output:               "source",
+				structName:           "foo",
+				transform:            "snakecase",
+				skipUnexportedFields: true,
 			},
 		},
 		{
 			file: "skip_private_multiple_names",
 			cfg: &config{
-				add:               []string{"json"},
-				output:            "source",
-				structName:        "foo",
-				transform:         "snakecase",
-				skipPrivateFields: true,
+				add:                  []string{"json"},
+				output:               "source",
+				structName:           "foo",
+				transform:            "snakecase",
+				skipUnexportedFields: true,
 			},
 		},
 	}


### PR DESCRIPTION
Rename the --skip-private flag to --skip-unexported to use the usual Go
nomenclature.