### PR TITLE
allow equals in tag values

### DIFF
--- a/main.go
+++ b/main.go
@@ -311,12 +311,12 @@ func (c *config) removeTagOptions(tags *structtag.Tags) (*structtag.Tags, error)
 	for _, val := range c.removeOptions {
 		// syntax key=option
 		splitted := strings.Split(val, "=")
-		if len(splitted) != 2 {
+		if len(splitted) < 2 {
 			return nil, errors.New("wrong syntax to remove an option. i.e key=option")
 		}
 
 		key := splitted[0]
-		option := splitted[1]
+		option := strings.Join(splitted[1:], "=")
 
 		tags.DeleteOptions(key, option)
 	}
@@ -332,12 +332,12 @@ func (c *config) addTagOptions(tags *structtag.Tags) (*structtag.Tags, error) {
 	for _, val := range c.addOptions {
 		// syntax key=option
 		splitted := strings.Split(val, "=")
-		if len(splitted) != 2 {
+		if len(splitted) < 2 {
 			return nil, errors.New("wrong syntax to add an option. i.e key=option")
 		}
 
 		key := splitted[0]
-		option := splitted[1]
+		option := strings.Join(splitted[1:], "=")
 
 		tags.AddOptions(key, option)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -205,6 +205,16 @@ func TestRewrite(t *testing.T) {
 			},
 		},
 		{
+			file: "line_add_option_with_equal",
+			cfg: &config{
+				addOptions: []string{"validate=max=32"},
+				add:        []string{"validate"},
+				output:     "source",
+				line:       "4,7",
+				transform:  "snakecase",
+			},
+		},
+		{
 			file: "line_remove",
 			cfg: &config{
 				remove: []string{"json"},
@@ -224,6 +234,14 @@ func TestRewrite(t *testing.T) {
 			file: "line_remove_options",
 			cfg: &config{
 				removeOptions: []string{"json=omitempty", "hcl=omitnested"},
+				output:        "source",
+				line:          "4,7",
+			},
+		},
+		{
+			file: "line_remove_option_with_equal",
+			cfg: &config{
+				removeOptions: []string{"validate=max=32"},
 				output:        "source",
 				line:          "4,7",
 			},

--- a/test-fixtures/line_add_option_with_equal.golden
+++ b/test-fixtures/line_add_option_with_equal.golden
@@ -1,0 +1,7 @@
+package foo
+
+type foo struct {
+	bar string `validate:"bar,max=32"`
+	t   bool   `json:"t" validate:"t,max=32"`
+	qux int    `json:"qux" validate:"qux,max=32"`
+}

--- a/test-fixtures/line_add_option_with_equal.input
+++ b/test-fixtures/line_add_option_with_equal.input
@@ -1,0 +1,7 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool `json:"t"`
+	qux int  `json:"qux"`
+}

--- a/test-fixtures/line_remove_option_with_equal.golden
+++ b/test-fixtures/line_remove_option_with_equal.golden
@@ -1,0 +1,7 @@
+package foo
+
+type foo struct {
+	bar string `validate:"bar"`
+	t   bool   `json:"t" validate:"t"`
+	qux int    `json:"qux" validate:"qux"`
+}

--- a/test-fixtures/line_remove_option_with_equal.input
+++ b/test-fixtures/line_remove_option_with_equal.input
@@ -1,0 +1,7 @@
+package foo
+
+type foo struct {
+	bar string `validate:"bar,max=32"`
+	t   bool   `json:"t" validate:"t,max=32"`
+	qux int    `json:"qux" validate:"qux,max=32"`
+}


### PR DESCRIPTION
support equals sign as part of a tag.  specifically, the validate package allows a user to define the validation as something like `validate:max=32` which will throw an error if the length is more then 32 chars.  

I added a couple of tests but I'm happy to add some more.  I'm also happy to say that something like `max=32=frank` should be disallowed to keep the scope of the this change small but there may be valid use cases for having more then one equal in the tag value.