### PR TITLE
Detect extra cases in struct declarations

### DIFF
--- a/main.go
+++ b/main.go
@@ -451,6 +451,25 @@ func collectStructs(node ast.Node) map[token.Pos]*structType {
 		case *ast.ValueSpec:
 			structName = x.Names[0].Name
 			t = x.Type
+		case *ast.Field:
+			if len(x.Names) > 0 {
+				structName = x.Names[0].Name
+			}
+			t = x.Type
+		}
+
+		// if found expression is a "*something" or "[]something",
+		// dereference to check if "something" contains a struct expression
+	loop:
+		for true {
+			switch x := t.(type) {
+			case *ast.StarExpr:
+				t = x.X
+			case *ast.ArrayType:
+				t = x.Elt
+			default:
+				break loop
+			}
 		}
 
 		x, ok := t.(*ast.StructType)

--- a/main.go
+++ b/main.go
@@ -430,25 +430,10 @@ func (c *config) addTags(fieldName string, tags *structtag.Tags) (*structtag.Tag
 	return tags, nil
 }
 
-// dereferenceExpression takes an expression, and removes all its leading "*" and "[]" operators
-//
-// use case : if found expression is a "*something" or "[]something", we need to check if "something" contains a struct expression
-func dereferenceExpression(expr ast.Expr) ast.Expr {
-	switch x := expr.(type) {
-	case *ast.StarExpr:
-		return dereferenceExpression(x.X)
-
-	case *ast.ArrayType:
-		return dereferenceExpression(x.Elt)
-
-	default:
-		return expr
-	}
-}
-
 // collectStructs collects and maps structType nodes to their positions
 func collectStructs(node ast.Node) map[token.Pos]*structType {
 	structs := make(map[token.Pos]*structType, 0)
+
 	collectStructs := func(n ast.Node) bool {
 		var t ast.Expr
 		var structName string
@@ -468,15 +453,28 @@ func collectStructs(node ast.Node) map[token.Pos]*structType {
 			structName = x.Names[0].Name
 			t = x.Type
 		case *ast.Field:
-			if len(x.Names) > 0 {
+			// this case also catches struct fields and the structName
+			// therefore might contain the field name (which is wrong)
+			// because `x.Type` in this case is not a *ast.StructType.
+			//
+			// We're OK with it, because, in our case *ast.Field represents
+			// a parameter declaration, i.e:
+			//
+			//   func test(arg struct {
+			//   	Field int
+			//   }) {
+			//   }
+			//
+			// and hence the struct name will be `arg`.
+			if len(x.Names) != 0 {
 				structName = x.Names[0].Name
 			}
 			t = x.Type
 		}
 
-		// if found expression is a "*something" or "[]something",
-		// dereference to check if "something" contains a struct expression
-		t = dereferenceExpression(t)
+		// if expression is in form "*T" or "[]T", dereference to check if "T"
+		// contains a struct expression
+		t = deref(t)
 
 		x, ok := t.(*ast.StructType)
 		if !ok {
@@ -489,6 +487,7 @@ func collectStructs(node ast.Node) map[token.Pos]*structType {
 		}
 		return true
 	}
+
 	ast.Inspect(node, collectStructs)
 	return structs
 }
@@ -866,4 +865,17 @@ func split(line string) (int, error) {
 	}
 
 	return 0, fmt.Errorf("couldn't parse line: '%s'", line)
+}
+
+// deref takes an expression, and removes all its leading "*" and "[]"
+// operator. Uuse case : if found expression is a "*t" or "[]t", we need to
+// check if "t" contains a struct expression.
+func deref(x ast.Expr) ast.Expr {
+	switch t := x.(type) {
+	case *ast.StarExpr:
+		return deref(t.X)
+	case *ast.ArrayType:
+		return deref(t.Elt)
+	}
+	return x
 }

--- a/main_test.go
+++ b/main_test.go
@@ -467,6 +467,33 @@ func TestRewrite(t *testing.T) {
 				fieldName:  "bar",
 			},
 		},
+		{
+			file: "offset_anonymous_struct",
+			cfg: &config{
+				add:       []string{"json"},
+				output:    "source",
+				offset:    45,
+				transform: "camelcase",
+			},
+		},
+		{
+			file: "offset_star_struct",
+			cfg: &config{
+				add:       []string{"json"},
+				output:    "source",
+				offset:    35,
+				transform: "camelcase",
+			},
+		},
+		{
+			file: "offset_array_struct",
+			cfg: &config{
+				add:       []string{"json"},
+				output:    "source",
+				offset:    35,
+				transform: "camelcase",
+			},
+		},
 	}
 
 	for _, ts := range test {

--- a/test-fixtures/offset_anonymous_struct.golden
+++ b/test-fixtures/offset_anonymous_struct.golden
@@ -1,0 +1,6 @@
+package main
+
+func test(arg struct {
+	Field int `json:"field"`
+}) {
+}

--- a/test-fixtures/offset_anonymous_struct.input
+++ b/test-fixtures/offset_anonymous_struct.input
@@ -1,0 +1,6 @@
+package main
+
+func test(arg struct {
+	Field int
+}) {
+}

--- a/test-fixtures/offset_array_struct.golden
+++ b/test-fixtures/offset_array_struct.golden
@@ -1,0 +1,5 @@
+package main
+
+var x []struct {
+	Field int `json:"field"`
+}

--- a/test-fixtures/offset_array_struct.input
+++ b/test-fixtures/offset_array_struct.input
@@ -1,0 +1,5 @@
+package main
+
+var x []struct {
+	Field int
+}

--- a/test-fixtures/offset_star_struct.golden
+++ b/test-fixtures/offset_star_struct.golden
@@ -1,0 +1,5 @@
+package main
+
+var x *struct {
+	Field int `json:"field"`
+}

--- a/test-fixtures/offset_star_struct.input
+++ b/test-fixtures/offset_star_struct.input
@@ -1,0 +1,5 @@
+package main
+
+var x *struct {
+	Field int
+}


### PR DESCRIPTION
Handle the following extra cases :
* anonymous structs in function signature
* "pointer to struct" type declaration
* "array of struct" type declaration

and nested variants : "array of pointers to array of structs" ...

Fixes #63 