### PR TITLE
Rename `format` to `template` to avoid clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ form: `json:"server"` (assuming `-add-tags=json` is used).
 
 However, some third party libraries use tags in a different way and might
 require to them to have a particular formatting, such as is the case of
-prefixing them (`field_name=<your_value>`). The `--format` flag allows you to
+prefixing them (`field_name=<your_value>`). The `--template` flag allows you to
 specify a custom format for the tag value to be applied.
 
 ```
-$ gomodifytags -file demo.go -struct Server -add-tags gaum -format "field_name=$field" 
+$ gomodifytags -file demo.go -struct Server -add-tags gaum -template "field_name=$field" 
 ```
 
 ```go

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func realMain() error {
 			"Sort sorts the tags in increasing order according to the key name")
 
 		// formatting
-		flagFormatting = flag.String("format", "",
+		flagFormatting = flag.String("template", "",
 			"Format the given tag's value. i.e: \"column:$field\", \"field_name=$field\"")
 
 		// option flags


### PR DESCRIPTION
When I applied the last change it all checked out and tests passed but I missed that `format` was shadowed by another flag used currently to signal the type of output, apologies @fatih I just realized when doing the changes to the vscode plug in to integrate this.