### PR TITLE
Add external config file to config editors 

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,3 +600,18 @@ GO111MODULE=on go test -v -mod=vendor
 ```
 
 If everything works fine, feel free to open a pull request with your changes.
+
+
+# Use external config file
+
+when we use  editors like vscode  to add tags, the vscode can only add json tags for us, there is no way to change the config, so I add a toml config support.
+we just need add a `gomodifytags.toml` in the same directory of gomodifytags. in linux we can use `whereis gomodifytags` to get the directory.
+```toml
+Add = ["form", "gorm"]
+Transform = "camelcase"
+[TemplateMap]
+  gorm = "column:$field"
+```
+
+- the `Add` will add external tags to user tag.
+- the `TemplateMap` will add template for each tag

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/fatih/gomodifytags
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/fatih/camelcase v1.0.0
 	github.com/fatih/structtag v1.2.0
 	golang.org/x/tools v0.0.0-20180824175216-6c1c5e93cdc1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=

--- a/main.go
+++ b/main.go
@@ -134,9 +134,7 @@ func parseConfig(args []string) (*config, error) {
 	ex, err := os.Executable()
 	if err == nil {
 		exPath := filepath.Dir(ex)
-		if _, err := toml.DecodeFile(filepath.Join(exPath, "gomodifytags.toml"), &tomlCfg); err != nil {
-			fmt.Println(err)
-		}
+		toml.DecodeFile(filepath.Join(exPath, "gomodifytags.toml"), &tomlCfg)
 	}
 
 	var (


### PR DESCRIPTION
# Use external config file

when we use  editors like vscode  to add tags, the vscode can only add json tags for us, there is no way to change the config, so I add a toml config support.
we just need add a `gomodifytags.toml` in the same directory of gomodifytags. in linux we can use `whereis gomodifytags` to get the directory.
```toml
Add = ["form", "gorm"]
Transform = "camelcase"
[TemplateMap]
  gorm = "column:$field"
```

- the `Add` will add external tags to flag tag.
- the `TemplateMap` will add template for each tag,overwrite the flag template


![lupin2](https://user-images.githubusercontent.com/5291739/123039779-53382900-d425-11eb-9ae9-daa84f00bb23.gif)
