### PR TITLE
[bugfix] change a symbol to replace the special symbol #76

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func parseConfig(args []string) (*config, error) {
 
 		// formatting
 		flagFormatting = flag.String("template", "",
-			"Format the given tag's value. i.e: \"column:$field\", \"field_name=$field\"")
+			"Format the given tag's value. i.e: \"column:{field}\", \"field_name={field}\"")
 
 		// option flags
 		flagRemoveOptions = flag.String("remove-options", "",
@@ -420,7 +420,7 @@ func (c *config) addTags(fieldName string, tags *structtag.Tags) (*structtag.Tag
 	}
 
 	if c.valueFormat != "" {
-		name = strings.ReplaceAll(c.valueFormat, "$field", name)
+		name = strings.ReplaceAll(c.valueFormat, "{field}", name)
 	}
 
 	for _, key := range c.add {

--- a/main_test.go
+++ b/main_test.go
@@ -48,7 +48,7 @@ func TestRewrite(t *testing.T) {
 				output:      "source",
 				structName:  "foo",
 				transform:   "snakecase",
-				valueFormat: "field_name=$field",
+				valueFormat: "field_name={field}",
 			},
 		},
 		{
@@ -58,7 +58,7 @@ func TestRewrite(t *testing.T) {
 				output:      "source",
 				structName:  "foo",
 				transform:   "snakecase",
-				valueFormat: "field_name=$field",
+				valueFormat: "field_name={field}",
 			},
 		},
 		{


### PR DESCRIPTION
Whether it is win or linux, "$" is a special character. If you want to enter "$" on linux, you must use "\$". Very troublesome... and it doesn't work on win. . .. Why not just change a symbol to mark this variable?