### PR TITLE
 Add external config file support to make editors configurable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,3 +600,18 @@ GO111MODULE=on go test -v -mod=vendor
 ```
 
 If everything works fine, feel free to open a pull request with your changes.
+
+
+# Use external config file
+
+when we use  editors like vscode  to add tags, the vscode can only add json tags for us, there is no way to change the config, so I add a toml config support.
+we just need add a `gomodifytags.toml` in the same directory of gomodifytags. in linux we can use `whereis gomodifytags` to get the directory.
+```toml
+Add = ["form", "gorm"]
+Transform = "camelcase"
+[TemplateMap]
+  gorm = "column:$field"
+```
+
+- the `Add` will add external tags to user tag.
+- the `TemplateMap` will add template for each tag

--- a/README.md
+++ b/README.md
@@ -573,6 +573,28 @@ Each archive entry consists of:
  - the (decimal) file size, followed by a newline
  - the contents of the file
 
+## Use external config file
+
+when we use  editors like vscode  to add tags, the vscode can only add json tags for us, there is no way to change the config, so I add a toml config support.
+we just need add a `gomodifytags.toml` in the same directory of gomodifytags. in linux we can use `whereis gomodifytags` to get the directory.
+```toml
+Add = ["form", "gorm","binding"]
+Transform = "camelcase"
+[TemplateMap]
+  gorm = "column:$field"
+  binding = "required"
+[TransformMap]
+  gorm = "snakecase"
+
+```
+
+- the `Add` will add external tags to flag tag.
+- the `Transform` will config transform for all tag.
+- the `TemplateMap` will config template for each tag,overwrite the flag template.
+- the `TransformMap` will config transform for each tag,overwrite the flag transform and Transform.
+
+![gomodifytags](https://user-images.githubusercontent.com/5291739/123039779-53382900-d425-11eb-9ae9-daa84f00bb23.gif)
+
 # Development
 
 At least Go `v1.11.x` is required. Older versions might work, but it's not
@@ -602,18 +624,3 @@ GO111MODULE=on go test -v -mod=vendor
 If everything works fine, feel free to open a pull request with your changes.
 
 
-# Use external config file
-
-when we use  editors like vscode  to add tags, the vscode can only add json tags for us, there is no way to change the config, so I add a toml config support.
-we just need add a `gomodifytags.toml` in the same directory of gomodifytags. in linux we can use `whereis gomodifytags` to get the directory.
-```toml
-Add = ["form", "gorm"]
-Transform = "camelcase"
-[TemplateMap]
-  gorm = "column:$field"
-```
-
-- the `Add` will add external tags to flag tag.
-- the `TemplateMap` will add template for each tag,overwrite the flag template.
-
-![gomodifytags](https://user-images.githubusercontent.com/5291739/123039779-53382900-d425-11eb-9ae9-daa84f00bb23.gif)

--- a/README.md
+++ b/README.md
@@ -613,5 +613,7 @@ Transform = "camelcase"
   gorm = "column:$field"
 ```
 
-- the `Add` will add external tags to user tag.
-- the `TemplateMap` will add template for each tag
+- the `Add` will add external tags to flag tag.
+- the `TemplateMap` will add template for each tag,overwrite the flag template.
+
+https://user-images.githubusercontent.com/5291739/123039779-53382900-d425-11eb-9ae9-daa84f00bb23.gif

--- a/README.md
+++ b/README.md
@@ -616,4 +616,4 @@ Transform = "camelcase"
 - the `Add` will add external tags to flag tag.
 - the `TemplateMap` will add template for each tag,overwrite the flag template.
 
-https://user-images.githubusercontent.com/5291739/123039779-53382900-d425-11eb-9ae9-daa84f00bb23.gif
+![gomodifytags](https://user-images.githubusercontent.com/5291739/123039779-53382900-d425-11eb-9ae9-daa84f00bb23.gif)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/fatih/gomodifytags
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/fatih/camelcase v1.0.0
 	github.com/fatih/structtag v1.2.0
 	golang.org/x/tools v0.0.0-20180824175216-6c1c5e93cdc1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=

--- a/main.go
+++ b/main.go
@@ -134,9 +134,7 @@ func parseConfig(args []string) (*config, error) {
 	ex, err := os.Executable()
 	if err == nil {
 		exPath := filepath.Dir(ex)
-		if _, err := toml.DecodeFile(filepath.Join(exPath, "gomodifytags.toml"), &tomlCfg); err != nil {
-			fmt.Println(err)
-		}
+		toml.DecodeFile(filepath.Join(exPath, "gomodifytags.toml"), &tomlCfg)
 	}
 
 	var (

--- a/main.go
+++ b/main.go
@@ -229,19 +229,17 @@ func parseConfig(args []string) (*config, error) {
 
 	// add extenal tags config
 	if *flagAddTags != "" {
-		inputAdds := strings.Split(*flagAddTags, ",")
+		cfg.add = strings.Split(*flagAddTags, ",")
 
 		// remove duplicate tag
 		addMap := make(map[string]struct{})
-		for _, add := range inputAdds {
+		for _, add := range cfg.add {
 			addMap[add] = struct{}{}
 		}
 		for _, add := range tomlCfg.Add {
-			addMap[add] = struct{}{}
-		}
-
-		for add, _ := range addMap {
-			cfg.add = append(cfg.add, add)
+			if _, ok := addMap[add]; !ok {
+				cfg.add = append(cfg.add, add)
+			}
 		}
 
 	}


### PR DESCRIPTION
## Use external config file

when we use  editors like vscode  to add tags, the vscode can only add json tags for us, there is no way to change the config, so I add a toml config support.
we just need add a `gomodifytags.toml` in the same directory of gomodifytags. in linux we can use `whereis gomodifytags` to get the directory.
```toml
Add = ["form", "gorm","binding"]
Transform = "camelcase"
[TemplateMap]
  gorm = "column:$field"
  binding = "required"
[TransformMap]
  gorm = "snakecase"

```

- the `Add` will add external tags to flag tag.
- the `Transform` will config transform for all tag.
- the `TemplateMap` will config template for each tag,overwrite the flag template.
- the `TransformMap` will config transform for each tag,overwrite the flag transform and Transform.

![gomodifytags](https://user-images.githubusercontent.com/5291739/123039779-53382900-d425-11eb-9ae9-daa84f00bb23.gif)

