### PR TITLE
Change `$field` keyword to `{field}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ prefixing them (`field_name=<your_value>`). The `--template` flag allows you to
 specify a custom format for the tag value to be applied.
 
 ```
-$ gomodifytags -file demo.go -struct Server -add-tags gaum -template "field_name=$field" 
+$ gomodifytags -file demo.go -struct Server -add-tags gaum -template "field_name={field}" 
 ```
 
 ```go
@@ -175,7 +175,7 @@ type Server struct {
 }
 ```
 
-The `$field` is a special keyword that is replaced by the struct tag's value
+The `{field}` word is a special keyword that is replaced by the struct tag's value
 **after** the [transformation](https://github.com/fatih/gomodifytags#transformations). 
 
 ### Transformations

--- a/main.go
+++ b/main.go
@@ -420,7 +420,12 @@ func (c *config) addTags(fieldName string, tags *structtag.Tags) (*structtag.Tag
 	}
 
 	if c.valueFormat != "" {
+		prevName := name
 		name = strings.ReplaceAll(c.valueFormat, "{field}", name)
+		if name == c.valueFormat {
+			// support old style for backward compatibility
+			name = strings.ReplaceAll(c.valueFormat, "$field", prevName)
+		}
 	}
 
 	for _, key := range c.add {

--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func parseConfig(args []string) (*config, error) {
 
 		// formatting
 		flagFormatting = flag.String("template", "",
-			"Format the given tag's value. i.e: \"column:$field\", \"field_name=$field\"")
+			"Format the given tag's value. i.e: \"column:{field}\", \"field_name={field}\"")
 
 		// option flags
 		flagRemoveOptions = flag.String("remove-options", "",
@@ -420,7 +420,7 @@ func (c *config) addTags(fieldName string, tags *structtag.Tags) (*structtag.Tag
 	}
 
 	if c.valueFormat != "" {
-		name = strings.ReplaceAll(c.valueFormat, "$field", name)
+		name = strings.ReplaceAll(c.valueFormat, "{field}", name)
 	}
 
 	for _, key := range c.add {

--- a/main_test.go
+++ b/main_test.go
@@ -48,7 +48,7 @@ func TestRewrite(t *testing.T) {
 				output:      "source",
 				structName:  "foo",
 				transform:   "snakecase",
-				valueFormat: "field_name=$field",
+				valueFormat: "field_name={field}",
 			},
 		},
 		{
@@ -58,7 +58,7 @@ func TestRewrite(t *testing.T) {
 				output:      "source",
 				structName:  "foo",
 				transform:   "snakecase",
-				valueFormat: "field_name=$field",
+				valueFormat: "field_name={field}",
 			},
 		},
 		{

--- a/main_test.go
+++ b/main_test.go
@@ -62,6 +62,26 @@ func TestRewrite(t *testing.T) {
 			},
 		},
 		{
+			file: "struct_format_oldstyle",
+			cfg: &config{
+				add:         []string{"gaum"},
+				output:      "source",
+				structName:  "foo",
+				transform:   "snakecase",
+				valueFormat: "field_name=$field",
+			},
+		},
+		{
+			file: "struct_format_existing_oldstyle",
+			cfg: &config{
+				add:         []string{"gaum"},
+				output:      "source",
+				structName:  "foo",
+				transform:   "snakecase",
+				valueFormat: "field_name=$field",
+			},
+		},
+		{
 			file: "struct_remove",
 			cfg: &config{
 				remove:     []string{"json"},

--- a/test-fixtures/struct_format_existing_oldstyle.golden
+++ b/test-fixtures/struct_format_existing_oldstyle.golden
@@ -1,0 +1,6 @@
+package foo
+
+type foo struct {
+	bar       string    `gaum:"field_name=bar"`
+	timestamp time.Time `gaum:"@timestamp"`
+}

--- a/test-fixtures/struct_format_existing_oldstyle.input
+++ b/test-fixtures/struct_format_existing_oldstyle.input
@@ -1,0 +1,6 @@
+package foo
+
+type foo struct {
+	bar       string
+	timestamp time.Time `gaum:"@timestamp"`
+}

--- a/test-fixtures/struct_format_oldstyle.golden
+++ b/test-fixtures/struct_format_oldstyle.golden
@@ -1,0 +1,6 @@
+package foo
+
+type foo struct {
+	bar string `gaum:"field_name=bar"`
+	t   bool   `gaum:"field_name=t"`
+}

--- a/test-fixtures/struct_format_oldstyle.input
+++ b/test-fixtures/struct_format_oldstyle.input
@@ -1,0 +1,6 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool
+}


### PR DESCRIPTION
Includes changes from https://github.com/fatih/gomodifytags/pull/79, but has support for old-style `$field` templating for backward compatibility. 

fixes: https://github.com/fatih/gomodifytags/issues/76