### PR TITLE
Add `--quiet` flag to suppress output to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,18 @@ type Server struct {
 }
 ```
 
-By default every change will be printed to stdout. So it's safe to run it and
-see the results of it. If you want to change it permanently, pass the `-w`
-(write) flag.
+By default changes will be printed to stdout and can be used for dry-run your
+changes before making destructive changes. If you want to change it permanently,
+pass the `-w` (write) flag.
 
 ```
 $ gomodifytags -file demo.go -struct Server -add-tags json -w
+```
+
+You can disable printing the results to stdout with the `--quiet` flag:
+
+```
+$ gomodifytags -file demo.go -struct Server -add-tags json -w --quiet
 ```
 
 You can pass multiple keys to add tags. The following will add `json` and `xml`

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ type output struct {
 type config struct {
 	file     string
 	output   string
+	quiet    bool
 	write    bool
 	modified io.Reader
 
@@ -114,7 +115,9 @@ func realMain() error {
 		return err
 	}
 
-	fmt.Println(out)
+	if !cfg.quiet {
+		fmt.Println(out)
+	}
 	return nil
 }
 
@@ -122,8 +125,9 @@ func parseConfig(args []string) (*config, error) {
 	var (
 		// file flags
 		flagFile  = flag.String("file", "", "Filename to be parsed")
-		flagWrite = flag.Bool("w", false,
-			"Write result to (source) file instead of stdout")
+		flagWrite = flag.Bool("w", false, "Write results to (source) file")
+		flagQuiet = flag.Bool("quiet", false, "Don't print result to stdout")
+
 		flagOutput = flag.String("format", "source", "Output format."+
 			"By default it's the whole file. Options: [source, json]")
 		flagModified = flag.Bool("modified", false, "read an archive of modified files from standard input")
@@ -188,6 +192,7 @@ func parseConfig(args []string) (*config, error) {
 		all:                  *flagAll,
 		output:               *flagOutput,
 		write:                *flagWrite,
+		quiet:                *flagQuiet,
 		clear:                *flagClearTags,
 		clearOption:          *flagClearOptions,
 		transform:            *flagTransform,


### PR DESCRIPTION
This PR adds the new `--quiet` flag. When passed, `gomodofiytags` won't output the results to stdout. This flag might be helpful for users who use `gomodifytags` for scripting in conjunction with the `-w` flag.

fixes: https://github.com/fatih/gomodifytags/issues/84
