### PR TITLE
When adding a bson tag and the tag name is "id", rename the id to "_id"

### DIFF
--- a/main.go
+++ b/main.go
@@ -455,6 +455,9 @@ func (c *config) addTags(fieldName string, tags *structtag.Tags) (*structtag.Tag
 		tag, err := tags.Get(key)
 		if err != nil {
 			// tag doesn't exist, create a new one
+			if name == "id" && key == "bson" {
+				name = "_id"
+			}
 			tag = &structtag.Tag{
 				Key:  key,
 				Name: name,


### PR DESCRIPTION
bson is used for mongodb, and the id in the database also named _id, this is a specal treatment, hope to support it.