### PR TITLE
Don't double up underscores with -transform=snakecase

### DIFF
--- a/main.go
+++ b/main.go
@@ -391,6 +391,10 @@ func (c *config) addTags(fieldName string, tags *structtag.Tags) (*structtag.Tag
 	case "snakecase":
 		var lowerSplitted []string
 		for _, s := range splitted {
+			s = strings.Trim(s, "_")
+			if s == "" {
+				continue
+			}
 			lowerSplitted = append(lowerSplitted, strings.ToLower(s))
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -33,6 +33,15 @@ func TestRewrite(t *testing.T) {
 			},
 		},
 		{
+			file: "struct_add_underscore",
+			cfg: &config{
+				add:        []string{"json"},
+				output:     "source",
+				structName: "foo",
+				transform:  "snakecase",
+			},
+		},
+		{
 			file: "struct_add_existing",
 			cfg: &config{
 				add:        []string{"json"},

--- a/test-fixtures/struct_add_underscore.golden
+++ b/test-fixtures/struct_add_underscore.golden
@@ -1,0 +1,5 @@
+package foo
+
+type foo struct {
+	foo_bar string `json:"foo_bar"`
+}

--- a/test-fixtures/struct_add_underscore.input
+++ b/test-fixtures/struct_add_underscore.input
@@ -1,0 +1,5 @@
+package foo
+
+type foo struct {
+	foo_bar string
+}


### PR DESCRIPTION
It would treat an existing underscore as a "word", so one underscore got transformed in to 3.

I run in to this semi-regularly when I copy something like a database schema to a struct:

	type Sequence struct {
		sequence_id  int64
		server_id    int32
		data_type    string
		increment_by int64
		cache_size   int64
	}

And this gets transformed to:

	type Sequence struct {
		sequence_id  int64 `db:"sequence___id"`
		server_id    int32 `db:"server___id"`
		data_type    string `db:"data___type"`
		increment_by int64  `db:"increment___by"`
		cache_size   int64  `db:"cache___size"`
	}

I could fix up the field names first, which needs to be done anyway, or use `-transform keep`, but this makes it do the right thing with the defaults with a minimal of friction, and I don't expect it to break anything for anyone.