### PR TITLE
Extract gomodifytags to a library

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Staticcheck
       uses: dominikh/staticcheck-action@v1.3.0
       with:
-        version: "2023.1.7"
+        version: "2025.1"
         install-go: false
 
     - name: Build

--- a/README.md
+++ b/README.md
@@ -386,6 +386,12 @@ type Server struct {
 }
 ```
 
+To remove multiple options from the same tag, you can repeat the tag name. For example:
+
+```
+$ gomodifytags -file demo.go -struct Server -remove-options json=first_option,json=other_option
+```
+
 Lastly, to remove all options without explicitly defining the keys and names,
 we can use the `-clear-options` flag. The following example will remove all
 options for the given struct:

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/fatih/gomodifytags/modifytags"
 )
 
 var update = flag.Bool("update", false, "update golden (.out) files")
@@ -18,548 +20,719 @@ var update = flag.Bool("update", false, "update golden (.out) files")
 // This is the directory where our test fixtures are.
 const fixtureDir = "./test-fixtures"
 
+func TestParseFlags(t *testing.T) {
+	// don't output help message during the test
+	flag.CommandLine.SetOutput(ioutil.Discard)
+
+	// The flag.CommandLine.Parse() call fails if there are flags re-defined
+	// with the same name. If there are duplicates, parseFlags() will return
+	// an error.
+	_, _, err := parseFlags([]string{"test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRewrite(t *testing.T) {
 	test := []struct {
 		cfg  *config
+		mod  *modifytags.Modification
 		file string
+		err  error
 	}{
 		{
 			file: "struct_add",
 			cfg: &config{
-				add:        []string{"json"},
 				output:     "source",
 				structName: "foo",
-				transform:  "snakecase",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "struct_add_underscore",
 			cfg: &config{
-				add:        []string{"json"},
 				output:     "source",
 				structName: "foo",
-				transform:  "snakecase",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "struct_add_existing",
+
 			cfg: &config{
-				add:        []string{"json"},
 				output:     "source",
 				structName: "foo",
-				transform:  "snakecase",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "struct_format",
 			cfg: &config{
-				add:         []string{"gaum"},
-				output:      "source",
-				structName:  "foo",
-				transform:   "snakecase",
-				valueFormat: "field_name={field}",
+				output:     "source",
+				structName: "foo",
+			},
+			mod: &modifytags.Modification{
+				Add:         []string{"gaum"},
+				Transform:   modifytags.SnakeCase,
+				ValueFormat: "field_name={field}",
 			},
 		},
 		{
 			file: "struct_format_existing",
 			cfg: &config{
-				add:         []string{"gaum"},
-				output:      "source",
-				structName:  "foo",
-				transform:   "snakecase",
-				valueFormat: "field_name={field}",
+				output:     "source",
+				structName: "foo",
+			},
+			mod: &modifytags.Modification{
+				Add:         []string{"gaum"},
+				Transform:   modifytags.SnakeCase,
+				ValueFormat: "field_name={field}",
 			},
 		},
 		{
 			file: "struct_format_oldstyle",
 			cfg: &config{
-				add:         []string{"gaum"},
-				output:      "source",
-				structName:  "foo",
-				transform:   "snakecase",
-				valueFormat: "field_name=$field",
+				output:     "source",
+				structName: "foo",
+			},
+			mod: &modifytags.Modification{
+				Add:         []string{"gaum"},
+				Transform:   modifytags.SnakeCase,
+				ValueFormat: "field_name={field}",
 			},
 		},
 		{
 			file: "struct_format_existing_oldstyle",
 			cfg: &config{
-				add:         []string{"gaum"},
-				output:      "source",
-				structName:  "foo",
-				transform:   "snakecase",
-				valueFormat: "field_name=$field",
+				output:     "source",
+				structName: "foo",
+			},
+			mod: &modifytags.Modification{
+				Add:         []string{"gaum"},
+				Transform:   modifytags.SnakeCase,
+				ValueFormat: "field_name={field}",
 			},
 		},
 		{
 			file: "struct_remove",
 			cfg: &config{
-				remove:     []string{"json"},
 				output:     "source",
 				structName: "foo",
+			},
+			mod: &modifytags.Modification{
+				Remove: []string{"json"},
 			},
 		},
 		{
 			file: "struct_clear_tags",
 			cfg: &config{
-				clear:      true,
 				output:     "source",
 				structName: "foo",
+			},
+			mod: &modifytags.Modification{
+				Clear: true,
 			},
 		},
 		{
 			file: "struct_clear_options",
 			cfg: &config{
-				clearOption: true,
-				output:      "source",
-				structName:  "foo",
+				output:     "source",
+				structName: "foo",
+			},
+			mod: &modifytags.Modification{
+				ClearOptions: true,
 			},
 		},
 		{
 			file: "line_add",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4",
-				transform: "snakecase",
+				output: "source",
+				line:   "4",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_add_override",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4,5",
-				transform: "snakecase",
-				override:  true,
+				output: "source",
+				line:   "4,5",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
+				Overwrite: true,
 			},
 		},
 		{
 			file: "line_add_override_column",
 			cfg: &config{
-				add:       []string{"json:MyBar:bar"},
-				output:    "source",
-				line:      "4,4",
-				transform: "snakecase",
-				override:  true,
+				output: "source",
+				line:   "4,4",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json:MyBar:bar"},
+				Transform: modifytags.SnakeCase,
+				Overwrite: true,
 			},
 		},
 		{
 			file: "line_add_override_mixed_column_and_equal",
 			cfg: &config{
-				add:       []string{"json:MyBar:bar:foo=qux"},
-				output:    "source",
-				line:      "4,4",
-				transform: "snakecase",
-				override:  true,
+				output: "source",
+				line:   "4,4",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json:MyBar:bar:foo=qux"},
+				Transform: modifytags.SnakeCase,
+				Overwrite: true,
 			},
 		},
 		{
 			file: "line_add_override_multi_equal",
 			cfg: &config{
-				add:       []string{"json:MyBar=bar=foo"},
-				output:    "source",
-				line:      "4,4",
-				transform: "snakecase",
-				override:  true,
+				output: "source",
+				line:   "4,4",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json:MyBar=bar=foo"},
+				Transform: modifytags.SnakeCase,
+				Overwrite: true,
 			},
 		},
 		{
 			file: "line_add_override_multi_column",
 			cfg: &config{
-				add:       []string{"json:MyBar:bar:foo"},
-				output:    "source",
-				line:      "4,4",
-				transform: "snakecase",
-				override:  true,
+				output: "source",
+				line:   "4,4",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json:MyBar:bar:foo"},
+				Transform: modifytags.SnakeCase,
+				Overwrite: true,
 			},
 		},
 		{
 			file: "line_add_no_override",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4,5",
-				transform: "snakecase",
+				output: "source",
+				line:   "4,5",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_add_outside",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "2,8",
-				transform: "snakecase",
+				output: "source",
+				line:   "2,8",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_add_outside_partial_start",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "2,5",
-				transform: "snakecase",
+				output: "source",
+				line:   "2,5",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_add_outside_partial_end",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "5,8",
-				transform: "snakecase",
+				output: "source",
+				line:   "5,8",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_add_intersect_partial",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "5,11",
-				transform: "snakecase",
+				output: "source",
+				line:   "5,11",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_add_comment",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "6,7",
-				transform: "snakecase",
+				output: "source",
+				line:   "6,7",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_add_option",
 			cfg: &config{
-				addOptions: []string{"json=omitempty"},
-				output:     "source",
-				line:       "4,7",
+				output: "source",
+				line:   "4,7",
+			},
+			mod: &modifytags.Modification{
+				AddOptions: map[string][]string{
+					"json": {"omitempty"},
+				},
 			},
 		},
 		{
 			file: "line_add_option_existing",
 			cfg: &config{
-				addOptions: []string{"json=omitempty"},
-				output:     "source",
-				line:       "6,8",
+				output: "source",
+				line:   "6,8",
+			},
+			mod: &modifytags.Modification{
+				AddOptions: map[string][]string{
+					"json": {"omitempty"},
+				},
 			},
 		},
 		{
 			file: "line_add_multiple_option",
 			cfg: &config{
-				addOptions: []string{"json=omitempty", "hcl=squash"},
-				add:        []string{"hcl"},
-				output:     "source",
-				line:       "4,7",
-				transform:  "snakecase",
+				output: "source",
+				line:   "4,7",
+			},
+			mod: &modifytags.Modification{
+				AddOptions: map[string][]string{
+					"json": {"omitempty"},
+					"hcl":  {"squash"},
+				},
+				Add:       []string{"hcl"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_add_option_with_equal",
 			cfg: &config{
-				addOptions: []string{"validate=max=32"},
-				add:        []string{"validate"},
-				output:     "source",
-				line:       "4,7",
-				transform:  "snakecase",
+				output: "source",
+				line:   "4,7",
+			},
+			mod: &modifytags.Modification{
+				AddOptions: map[string][]string{
+					"validate": {"max=32"},
+				},
+				Add:       []string{"validate"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_remove",
 			cfg: &config{
-				remove: []string{"json"},
 				output: "source",
 				line:   "5,7",
+			},
+			mod: &modifytags.Modification{
+				Remove: []string{"json"},
 			},
 		},
 		{
 			file: "line_remove_option",
 			cfg: &config{
-				removeOptions: []string{"hcl=squash"},
-				output:        "source",
-				line:          "4,8",
+				output: "source",
+				line:   "4,8",
+			},
+			mod: &modifytags.Modification{
+				RemoveOptions: map[string][]string{
+					"hcl": {"squash"},
+				},
 			},
 		},
 		{
 			file: "line_remove_options",
 			cfg: &config{
-				removeOptions: []string{"json=omitempty", "hcl=omitnested"},
-				output:        "source",
-				line:          "4,7",
+				output: "source",
+				line:   "4,7",
+			},
+			mod: &modifytags.Modification{
+				RemoveOptions: map[string][]string{
+					"hcl":  {"omitnested"},
+					"json": {"omitempty"},
+				},
 			},
 		},
 		{
 			file: "line_remove_option_with_equal",
 			cfg: &config{
-				removeOptions: []string{"validate=max=32"},
-				output:        "source",
-				line:          "4,7",
+				output: "source",
+				line:   "4,7",
+			},
+			mod: &modifytags.Modification{
+				RemoveOptions: map[string][]string{
+					"validate": {"max=32"},
+				},
 			},
 		},
 		{
 			file: "line_multiple_add",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "5,6",
-				transform: "camelcase",
+				output: "source",
+				line:   "5,6",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.CamelCase,
 			},
 		},
 		{
 			file: "line_lispcase_add",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4,6",
-				transform: "lispcase",
+				output: "source",
+				line:   "4,6",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.LispCase,
 			},
 		},
 		{
 			file: "line_camelcase_add",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4,5",
-				transform: "camelcase",
+				output: "source",
+				line:   "4,5",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.CamelCase,
 			},
 		},
 		{
 			file: "line_camelcase_add_embedded",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4,6",
-				transform: "camelcase",
+				output: "source",
+				line:   "4,6",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.CamelCase,
 			},
 		},
 		{
 			file: "line_value_add",
 			cfg: &config{
-				add:    []string{"json:foo"},
 				output: "source",
 				line:   "4,6",
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json:foo"},
 			},
 		},
 		{
 			file: "offset_add",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				offset:    32,
-				transform: "snakecase",
+				output: "source",
+				offset: 32,
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "offset_add_composite",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				offset:    40,
-				transform: "snakecase",
+				output: "source",
+				offset: 40,
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "offset_add_duplicate",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				offset:    209,
-				transform: "snakecase",
+				output: "source",
+				offset: 209,
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "offset_add_literal_in",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				offset:    46,
-				transform: "snakecase",
+				output: "source",
+				offset: 46,
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "offset_add_literal_out",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				offset:    32,
-				transform: "snakecase",
+				output: "source",
+				offset: 32,
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "errors",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4,7",
-				transform: "snakecase",
+				output: "source",
+				line:   "4,7",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_pascalcase_add",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4,5",
-				transform: "pascalcase",
+				output: "source",
+				line:   "4,5",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.PascalCase,
 			},
 		},
 		{
 			file: "line_pascalcase_add_embedded",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4,6",
-				transform: "pascalcase",
+				output: "source",
+				line:   "4,6",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.PascalCase,
 			},
 		},
 		{
 			file: "not_formatted",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "3,4",
-				transform: "snakecase",
+				output: "source",
+				line:   "3,4",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "skip_private",
 			cfg: &config{
-				add:                  []string{"json"},
-				output:               "source",
-				structName:           "foo",
-				transform:            "snakecase",
-				skipUnexportedFields: true,
+				output:     "source",
+				structName: "foo",
+			},
+			mod: &modifytags.Modification{
+				Add:                  []string{"json"},
+				Transform:            modifytags.SnakeCase,
+				SkipUnexportedFields: true,
 			},
 		},
 		{
 			file: "skip_private_multiple_names",
 			cfg: &config{
-				add:                  []string{"json"},
-				output:               "source",
-				structName:           "foo",
-				transform:            "snakecase",
-				skipUnexportedFields: true,
+				output:     "source",
+				structName: "foo",
+			},
+			mod: &modifytags.Modification{
+				Add:                  []string{"json"},
+				Transform:            modifytags.SnakeCase,
+				SkipUnexportedFields: true,
 			},
 		},
 		{
 			file: "skip_embedded",
 			cfg: &config{
-				add:                  []string{"json"},
-				output:               "source",
-				structName:           "StationCreated",
-				transform:            "snakecase",
-				skipUnexportedFields: true,
+				output:     "source",
+				structName: "StationCreated",
+			},
+			mod: &modifytags.Modification{
+				Add:                  []string{"json"},
+				Transform:            modifytags.SnakeCase,
+				SkipUnexportedFields: true,
 			},
 		},
 		{
 			file: "all_structs",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				all:       true,
-				transform: "snakecase",
+				output: "source",
+				all:    true,
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "line_titlecase_add",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4,6",
-				transform: "titlecase",
+				output: "source",
+				line:   "4,6",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.TitleCase,
 			},
 		},
 		{
 			file: "line_titlecase_add_embedded",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				line:      "4,6",
-				transform: "titlecase",
+				output: "source",
+				line:   "4,6",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.TitleCase,
 			},
 		},
 		{
 			file: "field_add",
 			cfg: &config{
-				add:        []string{"json"},
 				output:     "source",
 				structName: "foo",
 				fieldName:  "bar",
-				transform:  "snakecase",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "field_add_same_line",
 			cfg: &config{
-				add:        []string{"json"},
 				output:     "source",
 				structName: "foo",
 				fieldName:  "qux",
-				transform:  "snakecase",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "field_add_existing",
 			cfg: &config{
-				add:        []string{"json"},
 				output:     "source",
 				structName: "foo",
 				fieldName:  "bar",
-				transform:  "snakecase",
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.SnakeCase,
 			},
 		},
 		{
 			file: "field_clear_tags",
 			cfg: &config{
-				clear:      true,
 				output:     "source",
 				structName: "foo",
 				fieldName:  "bar",
+			},
+			mod: &modifytags.Modification{
+				Clear: true,
 			},
 		},
 		{
 			file: "field_clear_options",
 			cfg: &config{
-				clearOption: true,
-				output:      "source",
-				structName:  "foo",
-				fieldName:   "bar",
+				output:     "source",
+				structName: "foo",
+				fieldName:  "bar",
+			},
+			mod: &modifytags.Modification{
+				ClearOptions: true,
 			},
 		},
 		{
 			file: "field_remove",
 			cfg: &config{
-				remove:     []string{"json"},
 				output:     "source",
 				structName: "foo",
 				fieldName:  "bar",
+			},
+			mod: &modifytags.Modification{
+				Remove: []string{"json"},
 			},
 		},
 		{
 			file: "offset_anonymous_struct",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				offset:    45,
-				transform: "camelcase",
+				output: "source",
+				offset: 45,
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.CamelCase,
 			},
 		},
 		{
 			file: "offset_star_struct",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				offset:    35,
-				transform: "camelcase",
+				output: "source",
+				offset: 35,
+			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.CamelCase,
 			},
 		},
 		{
 			file: "offset_array_struct",
 			cfg: &config{
-				add:       []string{"json"},
-				output:    "source",
-				offset:    35,
-				transform: "camelcase",
+				output: "source",
+				offset: 35,
 			},
+			mod: &modifytags.Modification{
+				Add:       []string{"json"},
+				Transform: modifytags.CamelCase,
+			},
+		},
+		{
+			file: "empty_file",
+			cfg: &config{
+				output: "source",
+				all:    true,
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
+			},
+		},
+		{
+			file: "empty_file",
+			cfg: &config{
+				output: "source",
+				line:   "4,6",
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
+			},
+			err: errors.New("line selection \"4,6\" is invalid: 4 is not within [0, 1]"),
 		},
 	}
 
@@ -574,17 +747,29 @@ func TestRewrite(t *testing.T) {
 
 			start, end, err := ts.cfg.findSelection(node)
 			if err != nil {
-				t.Fatal(err)
+				if !reflect.DeepEqual(ts.err.Error(), err.Error()) {
+					t.Fatal(err)
+				}
+				return
 			}
 
-			rewrittenNode, err := ts.cfg.rewrite(node, start, end)
+			ts.cfg.start = ts.cfg.fset.Position(start).Line
+			ts.cfg.end = ts.cfg.fset.Position(end).Line
+
+			err = ts.mod.Apply(ts.cfg.fset, node, start, end)
 			if err != nil {
-				if _, ok := err.(*rewriteErrors); !ok {
+				if _, ok := err.(*modifytags.RewriteErrors); !ok {
 					t.Fatal(err)
 				}
 			}
 
-			out, err := ts.cfg.format(rewrittenNode, err)
+			var out string
+			if err != nil {
+				out, err = ts.cfg.format(node, err.(*modifytags.RewriteErrors))
+			} else {
+				out, err = ts.cfg.format(node, nil)
+			}
+
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -628,102 +813,129 @@ func TestRewrite(t *testing.T) {
 func TestJSON(t *testing.T) {
 	test := []struct {
 		cfg  *config
+		mod  *modifytags.Modification
 		file string
 		err  error
 	}{
 		{
 			file: "json_single",
 			cfg: &config{
-				add:  []string{"json"},
 				line: "5",
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 		{
 			file: "json_full",
 			cfg: &config{
-				add:  []string{"json"},
 				line: "4,6",
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 		{
 			file: "json_intersection",
 			cfg: &config{
-				add:  []string{"json"},
 				line: "5,16",
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 		{
 			// both small & end range larger than file
 			file: "json_single",
 			cfg: &config{
-				add:  []string{"json"},
-				line: "30,32", // invalid selection
+				line: "30,32", //invalid selection
 			},
-			err: errors.New("line selection is invalid"),
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
+			},
+			err: errors.New("line selection \"30,32\" is invalid: 30 is not within [0, 22]"),
 		},
 		{
 			// end range larger than file
 			file: "json_single",
 			cfg: &config{
-				add:  []string{"json"},
-				line: "4,50", // invalid selection
+				line: "4,50", //invalid selection
 			},
-			err: errors.New("line selection is invalid"),
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
+			},
+			err: errors.New("line selection \"4,50\" is invalid: 4 is not within [0, 22]"),
 		},
 		{
 			file: "json_errors",
 			cfg: &config{
-				add:  []string{"json"},
 				line: "4,7",
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 		{
 			file: "json_not_formatted",
 			cfg: &config{
-				add:  []string{"json"},
 				line: "3,4",
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 		{
 			file: "json_not_formatted_2",
 			cfg: &config{
-				add:  []string{"json"},
 				line: "3,3",
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 		{
 			file: "json_not_formatted_3",
 			cfg: &config{
-				add:    []string{"json"},
 				offset: 23,
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 		{
 			file: "json_not_formatted_4",
 			cfg: &config{
-				add:    []string{"json"},
 				offset: 51,
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 		{
 			file: "json_not_formatted_5",
 			cfg: &config{
-				add:    []string{"json"},
 				offset: 29,
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 		{
 			file: "json_not_formatted_6",
 			cfg: &config{
-				add:  []string{"json"},
 				line: "2,54",
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 		{
 			file: "json_all_structs",
 			cfg: &config{
-				add: []string{"json"},
 				all: true,
+			},
+			mod: &modifytags.Modification{
+				Add: []string{"json"},
 			},
 		},
 	}
@@ -734,7 +946,7 @@ func TestJSON(t *testing.T) {
 			// these are explicit and shouldn't be changed for this particular
 			// main test
 			ts.cfg.output = "json"
-			ts.cfg.transform = "camelcase"
+			ts.mod.Transform = modifytags.CamelCase
 
 			node, err := ts.cfg.parse()
 			if err != nil {
@@ -742,19 +954,32 @@ func TestJSON(t *testing.T) {
 			}
 
 			start, end, err := ts.cfg.findSelection(node)
+
+			ts.cfg.start = ts.cfg.fset.Position(start).Line
+			ts.cfg.end = ts.cfg.fset.Position(end).Line
+
 			if err != nil {
-				t.Fatal(err)
+				if !reflect.DeepEqual(ts.err.Error(), err.Error()) {
+					t.Fatal(err)
+				}
+				return
 			}
 
-			rewrittenNode, err := ts.cfg.rewrite(node, start, end)
+			err = ts.mod.Apply(ts.cfg.fset, node, start, end)
 			if err != nil {
-				if _, ok := err.(*rewriteErrors); !ok {
+				if _, ok := err.(*modifytags.RewriteErrors); !ok {
 					t.Fatal(err)
 				}
 			}
 
-			out, err := ts.cfg.format(rewrittenNode, err)
-			if !reflect.DeepEqual(err, ts.err) {
+			var out string
+			if err != nil {
+				out, err = ts.cfg.format(node, err.(*modifytags.RewriteErrors))
+			} else {
+				out, err = ts.cfg.format(node, nil)
+			}
+
+			if err != nil && ts.err != nil && !reflect.DeepEqual(err.Error(), ts.err.Error()) {
 				t.Logf("want: %v", ts.err)
 				t.Logf("got: %v", err)
 				t.Fatalf("unexpected error")
@@ -798,10 +1023,8 @@ func TestJSON(t *testing.T) {
 
 func TestModifiedRewrite(t *testing.T) {
 	cfg := &config{
-		add:        []string{"json"},
 		output:     "source",
 		structName: "foo",
-		transform:  "snakecase",
 		file:       "struct_add_modified",
 		modified: strings.NewReader(`struct_add_modified
 55
@@ -814,6 +1037,11 @@ type foo struct {
 `),
 	}
 
+	mod := &modifytags.Modification{
+		Add:       []string{"json"},
+		Transform: modifytags.SnakeCase,
+	}
+
 	node, err := cfg.parse()
 	if err != nil {
 		t.Fatal(err)
@@ -824,12 +1052,21 @@ type foo struct {
 		t.Fatal(err)
 	}
 
-	rewrittenNode, err := cfg.rewrite(node, start, end)
+	cfg.start = cfg.fset.Position(start).Line
+	cfg.end = cfg.fset.Position(end).Line
+
+	err = mod.Apply(cfg.fset, node, start, end)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := cfg.format(rewrittenNode, err)
+	var got string
+	if err != nil {
+		got, err = cfg.format(node, err.(*modifytags.RewriteErrors))
+	} else {
+		got, err = cfg.format(node, nil)
+	}
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -848,10 +1085,8 @@ type foo struct {
 
 func TestModifiedFileMissing(t *testing.T) {
 	cfg := &config{
-		add:        []string{"json"},
 		output:     "source",
 		structName: "foo",
-		transform:  "snakecase",
 		file:       "struct_add_modified",
 		modified: strings.NewReader(`file_that_doesnt_exist
 55
@@ -883,7 +1118,6 @@ func TestParseLines(t *testing.T) {
 
 		t.Run(ts.file, func(t *testing.T) {
 			filePath := filepath.Join(fixtureDir, fmt.Sprintf("%s.input", ts.file))
-
 			file, err := os.Open(filePath)
 			if err != nil {
 				t.Fatal(err)
@@ -895,10 +1129,10 @@ func TestParseLines(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			toBytes := func(lines []string) []byte {
+			toBytes := func(Lines []string) []byte {
 				var buf bytes.Buffer
-				for _, line := range lines {
-					buf.WriteString(line + "\n")
+				for _, Line := range Lines {
+					buf.WriteString(Line + "\n")
 				}
 				return buf.Bytes()
 			}
@@ -934,18 +1168,5 @@ func TestParseLines(t *testing.T) {
 			}
 
 		})
-	}
-}
-
-func TestParseConfig(t *testing.T) {
-	// don't output help message during the test
-	flag.CommandLine.SetOutput(ioutil.Discard)
-
-	// The flag.CommandLine.Parse() call fails if there are flags re-defined
-	// with the same name. If there are duplicates, parseConfig() will return
-	// an error.
-	_, err := parseConfig([]string{"test"})
-	if err != nil {
-		t.Fatal(err)
 	}
 }

--- a/modifytags/modifytags.go
+++ b/modifytags/modifytags.go
@@ -1,0 +1,369 @@
+package modifytags
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/fatih/camelcase"
+	"github.com/fatih/structtag"
+)
+
+// A Transform determines how Go field names will be translated into
+// names used in struct tags. For example, the [SnakeCase] transform
+// converts the field MyField into the json tag json:"my_field".
+type Transform int
+
+const (
+	NoTransform Transform = iota
+	SnakeCase             // MyField -> my_field
+	CamelCase             // MyField -> myField
+	LispCase              // MyField -> my-field
+	PascalCase            // MyField -> MyField
+	TitleCase             // MyField -> My Field
+	Keep                  // keep the existing field name
+)
+
+// A Modification defines how struct tags should be modified for a given input struct.
+type Modification struct {
+	Add        []string            // tags to add
+	AddOptions map[string][]string // options to add, per tag
+
+	Remove        []string            // tags to remove
+	RemoveOptions map[string][]string // options to remove, per tag
+
+	Overwrite            bool // if set, replace existing tags when adding
+	SkipUnexportedFields bool // if set, do not modify tags on unexported struct fields
+
+	Transform    Transform // transform rule for adding tags
+	Sort         bool      // if set, sort tags in ascending order by key name
+	ValueFormat  string    // format for the tag's value, after transformation; for example "column:{field}"
+	Clear        bool      // if set, clear all tags. tags are cleared before any new tags are added
+	ClearOptions bool      // if set, clear all tag options; options are cleared before any new options are added
+}
+
+// Apply applies the struct tag modifications of the receiver to all
+// struct fields contained within the given node between start and end position, modifying its input.
+func (mod *Modification) Apply(fset *token.FileSet, node ast.Node, start, end token.Pos) error {
+	err := mod.validate()
+	if err != nil {
+		return err
+	}
+
+	return mod.rewrite(fset, node, start, end)
+}
+
+// rewrite rewrites the node for structs between the start and end positions
+func (mod *Modification) rewrite(fset *token.FileSet, node ast.Node, start, end token.Pos) error {
+	var errs []error
+
+	rewriteFunc := func(n ast.Node) bool {
+		x, ok := n.(*ast.StructType)
+		if !ok {
+			return true
+		}
+
+		for _, f := range x.Fields.List {
+			if !(start <= f.End() && f.Pos() <= end) {
+				continue // not in range
+			}
+
+			fieldName := ""
+			if len(f.Names) != 0 {
+				for _, field := range f.Names {
+					if !mod.SkipUnexportedFields || isPublicName(field.Name) {
+						fieldName = field.Name
+						break
+					}
+				}
+			}
+
+			// anonymous field
+			if f.Names == nil {
+				ident, ok := f.Type.(*ast.Ident)
+				if !ok {
+					continue
+				}
+
+				if !mod.SkipUnexportedFields {
+					fieldName = ident.Name
+				}
+			}
+
+			// nothing to process, continue with next field
+			if fieldName == "" {
+				continue
+			}
+
+			if f.Tag == nil {
+				f.Tag = &ast.BasicLit{}
+			}
+
+			res, err := mod.processField(fieldName, f.Tag.Value)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("%s:%d:%d:%s",
+					fset.Position(f.Pos()).Filename,
+					fset.Position(f.Pos()).Line,
+					fset.Position(f.Pos()).Column,
+					err))
+				continue
+			}
+
+			f.Tag.Value = res
+		}
+
+		return true
+	}
+
+	ast.Inspect(node, rewriteFunc)
+
+	if len(errs) > 0 {
+		return &RewriteErrors{Errs: errs}
+	}
+	return nil
+}
+
+// processField returns the new struct tag value for the given field
+func (mod *Modification) processField(fieldName, tagVal string) (string, error) {
+	var tag string
+	if tagVal != "" {
+		var err error
+		tag, err = strconv.Unquote(tagVal)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	tags, err := structtag.Parse(tag)
+	if err != nil {
+		return "", err
+	}
+
+	tags = mod.removeTags(tags)
+	tags, err = mod.removeTagOptions(tags)
+	if err != nil {
+		return "", err
+	}
+
+	tags = mod.clearTags(tags)
+	tags = mod.clearOptions(tags)
+
+	tags, err = mod.addTags(fieldName, tags)
+	if err != nil {
+		return "", err
+	}
+
+	tags, err = mod.addTagOptions(tags)
+	if err != nil {
+		return "", err
+	}
+
+	if mod.Sort {
+		sort.Sort(tags)
+	}
+
+	res := tags.String()
+	if res != "" {
+		res = quote(tags.String())
+	}
+
+	return res, nil
+}
+
+func (mod *Modification) removeTags(tags *structtag.Tags) *structtag.Tags {
+	if len(mod.Remove) == 0 {
+		return tags
+	}
+
+	tags.Delete(mod.Remove...)
+	return tags
+}
+
+func (mod *Modification) clearTags(tags *structtag.Tags) *structtag.Tags {
+	if !mod.Clear {
+		return tags
+	}
+
+	tags.Delete(tags.Keys()...)
+	return tags
+}
+
+func (mod *Modification) clearOptions(tags *structtag.Tags) *structtag.Tags {
+	if !mod.ClearOptions {
+		return tags
+	}
+
+	for _, t := range tags.Tags() {
+		t.Options = nil
+	}
+
+	return tags
+}
+
+func (mod *Modification) removeTagOptions(tags *structtag.Tags) (*structtag.Tags, error) {
+	if len(mod.RemoveOptions) == 0 {
+		return tags, nil
+	}
+
+	for key, val := range mod.RemoveOptions {
+		for _, option := range val {
+			tags.DeleteOptions(key, option)
+		}
+	}
+
+	return tags, nil
+}
+
+func (mod *Modification) addTagOptions(tags *structtag.Tags) (*structtag.Tags, error) {
+	if len(mod.AddOptions) == 0 {
+		return tags, nil
+	}
+
+	for key, val := range mod.AddOptions {
+		tags.AddOptions(key, val...)
+	}
+
+	return tags, nil
+}
+
+func (mod *Modification) addTags(fieldName string, tags *structtag.Tags) (*structtag.Tags, error) {
+	if len(mod.Add) == 0 {
+		return tags, nil
+	}
+
+	split := camelcase.Split(fieldName)
+	name := ""
+
+	unknown := false
+	switch mod.Transform {
+	case SnakeCase:
+		var lowerSplit []string
+		for _, s := range split {
+			s = strings.Trim(s, "_")
+			if s == "" {
+				continue
+			}
+			lowerSplit = append(lowerSplit, strings.ToLower(s))
+		}
+
+		name = strings.Join(lowerSplit, "_")
+	case LispCase:
+		var lowerSplit []string
+		for _, s := range split {
+			lowerSplit = append(lowerSplit, strings.ToLower(s))
+		}
+
+		name = strings.Join(lowerSplit, "-")
+	case CamelCase:
+		var titled []string
+		for _, s := range split {
+			titled = append(titled, strings.Title(s))
+		}
+
+		titled[0] = strings.ToLower(titled[0])
+
+		name = strings.Join(titled, "")
+	case PascalCase:
+		var titled []string
+		for _, s := range split {
+			titled = append(titled, strings.Title(s))
+		}
+
+		name = strings.Join(titled, "")
+	case TitleCase:
+		var titled []string
+		for _, s := range split {
+			titled = append(titled, strings.Title(s))
+		}
+
+		name = strings.Join(titled, " ")
+	case Keep:
+		name = fieldName
+	default:
+		unknown = true
+	}
+
+	if mod.ValueFormat != "" {
+		prevName := name
+		name = strings.ReplaceAll(mod.ValueFormat, "{field}", name)
+		if name == mod.ValueFormat {
+			// support old style for backward compatibility
+			name = strings.ReplaceAll(mod.ValueFormat, "$field", prevName)
+		}
+	}
+
+	for _, key := range mod.Add {
+		split = strings.SplitN(key, ":", 2)
+		if len(split) >= 2 {
+			key = split[0]
+			name = strings.Join(split[1:], "")
+		} else if unknown {
+			// the user didn't pass any value but want to use an unknown
+			// transform. We don't return above in the default as the user
+			// might pass a value
+			return nil, fmt.Errorf("unknown transform option %q", mod.Transform)
+		}
+
+		tag, err := tags.Get(key)
+		if err != nil {
+			// tag doesn't exist, create a new one
+			tag = &structtag.Tag{
+				Key:  key,
+				Name: name,
+			}
+		} else if mod.Overwrite {
+			tag.Name = name
+		}
+
+		if err := tags.Set(tag); err != nil {
+			return nil, err
+		}
+	}
+
+	return tags, nil
+}
+
+func isPublicName(name string) bool {
+	for _, c := range name {
+		return unicode.IsUpper(c)
+	}
+	return false
+}
+
+// validate determines whether the Modification is valid or not.
+func (mod *Modification) validate() error {
+	if len(mod.Add) == 0 &&
+		len(mod.AddOptions) == 0 &&
+		!mod.Clear &&
+		!mod.ClearOptions &&
+		len(mod.RemoveOptions) == 0 &&
+		len(mod.Remove) == 0 {
+		return errors.New("one of " +
+			"[-add-tags, -add-options, -remove-tags, -remove-options, -clear-tags, -clear-options]" +
+			" should be defined")
+	}
+	return nil
+}
+
+func quote(tag string) string {
+	return "`" + tag + "`"
+}
+
+// RewriteErrors are errors that occurred while rewriting struct field tags.
+type RewriteErrors struct {
+	Errs []error
+}
+
+func (r *RewriteErrors) Error() string {
+	var buf bytes.Buffer
+	for _, e := range r.Errs {
+		buf.WriteString(fmt.Sprintf("%s\n", e.Error()))
+	}
+	return buf.String()
+}

--- a/modifytags/modifytags_test.go
+++ b/modifytags/modifytags_test.go
@@ -1,0 +1,134 @@
+package modifytags
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "update golden (.out) files")
+
+// This is the directory where our test fixtures are.
+const fixtureDir = "./test-fixtures"
+
+func TestApply(t *testing.T) {
+	var tests = []struct {
+		file  string
+		m     *Modification
+		start token.Pos
+		end   token.Pos
+	}{
+		{
+			file: "all_structs",
+			m: &Modification{
+				Add:       []string{"json"},
+				Transform: SnakeCase,
+			},
+			start: token.NoPos, // will be set to start of file
+			end:   token.NoPos, // will be set to end of file
+		},
+		{
+			file: "clear_all_tags",
+			m: &Modification{
+				Clear: true,
+			},
+			start: token.NoPos, // will be set to start of file
+			end:   token.NoPos, // will be set to end of file
+		},
+		{
+			file: "remove_some_tags",
+			m: &Modification{
+				Remove: []string{"json"},
+			},
+			start: token.NoPos, // will be set to start of file
+			end:   token.NoPos, // will be set to end of file
+		},
+		{
+			file: "add_tags_pos_between_line",
+			m: &Modification{
+				Add: []string{"json"},
+				AddOptions: map[string][]string{
+					"json": {"omitempty"},
+				},
+				Transform: SnakeCase,
+			},
+			// TODO: use markers in the test content to delineate start and end, rather than hard-coding here.
+			start: token.Pos(50),  // middle of second struct field
+			end:   token.Pos(200), // middle of fourth struct field
+		},
+	}
+
+	for _, ts := range tests {
+		ts := ts
+
+		t.Run(ts.file, func(t *testing.T) {
+			filePath := filepath.Join(fixtureDir, fmt.Sprintf("%s.input", ts.file))
+			file, err := os.Open(filePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+
+			fset := token.NewFileSet()
+
+			node, err := parser.ParseFile(fset, filepath.Join(fixtureDir, fmt.Sprintf("%s.input", ts.file)), nil, parser.ParseComments)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ts.start == token.NoPos {
+				ts.start = node.Pos()
+			}
+			if ts.end == token.NoPos {
+				ts.end = node.End()
+			}
+
+			err = ts.m.Apply(fset, node, ts.start, ts.end)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var got bytes.Buffer
+			err = format.Node(&got, fset, node)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// update golden file if necessary
+			golden := filepath.Join(fixtureDir, fmt.Sprintf("%s.golden", ts.file))
+
+			if *update {
+				err := ioutil.WriteFile(golden, got.Bytes(), 0644)
+				if err != nil {
+					t.Error(err)
+				}
+				return
+			}
+
+			// get golden file
+			want, err := ioutil.ReadFile(golden)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			from, err := ioutil.ReadFile(filePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// compare
+			if !bytes.Equal(got.Bytes(), want) {
+				t.Errorf("case %s\ngot:\n====\n\n%s\nwant:\n=====\n\n%s\nfrom:\n=====\n\n%s\n",
+					ts.file, got.Bytes(), want, from)
+			}
+
+		})
+	}
+}

--- a/modifytags/test-fixtures/add_tags_pos_between_line.golden
+++ b/modifytags/test-fixtures/add_tags_pos_between_line.golden
@@ -1,0 +1,8 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool   `json:"t,omitempty"`
+	qux string `json:"qux,omitempty"`
+	yoo string `json:"yoo,omitempty"`
+}

--- a/modifytags/test-fixtures/add_tags_pos_between_line.input
+++ b/modifytags/test-fixtures/add_tags_pos_between_line.input
@@ -1,0 +1,8 @@
+package foo
+
+type foo struct {
+	bar string
+	t   bool
+	qux string
+	yoo string
+}

--- a/modifytags/test-fixtures/all_structs.golden
+++ b/modifytags/test-fixtures/all_structs.golden
@@ -1,0 +1,22 @@
+package main
+
+type foo struct {
+	bar       string   `json:"bar"`
+	MyExample bool     `json:"my_example"`
+	MyAnother []string `json:"my_another"`
+}
+
+const exampleVar = "foo"
+
+type bar struct {
+	// loose comment
+
+	// home
+	ankara string `json:"ankara"`
+	yeap   bool   `json:"yeap"` // just a boolean
+
+	// great cities
+	cities []string `json:"cities"`
+
+	// seconed loose comment
+}

--- a/modifytags/test-fixtures/all_structs.input
+++ b/modifytags/test-fixtures/all_structs.input
@@ -1,0 +1,22 @@
+package main
+
+type foo struct {
+	bar       string
+	MyExample bool
+	MyAnother []string
+}
+
+const exampleVar = "foo"
+
+type bar struct {
+	// loose comment
+
+	// home
+	ankara string
+	yeap   bool // just a boolean
+
+	// great cities
+	cities []string
+
+	// seconed loose comment
+}

--- a/modifytags/test-fixtures/clear_all_tags.golden
+++ b/modifytags/test-fixtures/clear_all_tags.golden
@@ -1,0 +1,9 @@
+package foo
+
+type foo struct {
+	bar string 
+	t   bool   
+	t   bool   
+	qux string 
+	yoo string 
+}

--- a/modifytags/test-fixtures/clear_all_tags.input
+++ b/modifytags/test-fixtures/clear_all_tags.input
@@ -1,0 +1,9 @@
+package foo
+
+type foo struct {
+	bar string `json:"bar,omitempty" hcl:"bar,omitnested"`
+	t   bool   `hcl:"t"`
+	t   bool   `hcl:"t,omitempty"`
+	qux string `json:"qux,omitempty" hcl:"qux,squash,keys"`
+	yoo string `json:"yoo"`
+}

--- a/modifytags/test-fixtures/remove_some_tags.golden
+++ b/modifytags/test-fixtures/remove_some_tags.golden
@@ -1,0 +1,9 @@
+package main
+
+type foo struct {
+	bar string `hcl:"bar,omitnested"`
+	t   bool   `hcl:"t"`
+	t   bool   `hcl:"t,omitempty"`
+	qux string `hcl:"qux,squash,keys"`
+	yoo string 
+}

--- a/modifytags/test-fixtures/remove_some_tags.input
+++ b/modifytags/test-fixtures/remove_some_tags.input
@@ -1,0 +1,9 @@
+package main
+
+type foo struct {
+	bar string `json:"bar,omitempty" hcl:"bar,omitnested"`
+	t   bool   `hcl:"t"`
+	t   bool   `hcl:"t,omitempty"`
+	qux string `json:"qux,omitempty" hcl:"qux,squash,keys"`
+	yoo string `json:"yoo"`
+}

--- a/test-fixtures/empty_file.golden
+++ b/test-fixtures/empty_file.golden
@@ -1,0 +1,1 @@
+package foo

--- a/test-fixtures/empty_file.input
+++ b/test-fixtures/empty_file.input
@@ -1,0 +1,1 @@
+package foo


### PR DESCRIPTION
This PR moves the `gomodifytags` tool into its package to be imported by other applications (i.e.: `gopls`).

A new entrypoint into `gomodifytags` is provided via config.Apply(), which uses the specified start and end positions to apply struct tag modifications to the node without returning the new content.

related: golang/vscode-go#2002