### PR TITLE
Make snakecase the default in Apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ type Server struct {
 }
 ```
 
+The default transformation is `snake_case` when using the gomodifytags command
+and when calling Apply() - see section below for more information about Apply().
+
 If you prefer to use `camelCase` instead of `snake_case` for the values, you
 can use the `-transform` flag to define a different transformation rule. The
 following example uses the `camelcase` transformation rule:
@@ -304,7 +307,7 @@ type Server struct {
 }
 ```
 
-You can also remove multiple tags. The example below removs `json` and `xml`:
+You can also remove multiple tags. The example below removes `json` and `xml`:
 
 ```
 $ gomodifytags -file demo.go -struct Server -remove-tags json,xml
@@ -497,6 +500,14 @@ type Server struct {
 	} `json:"credentials" xml:"credentials"`
 }
 ```
+
+## Apply()
+
+In addition to the command line execution, gomodifytags is also available
+as a library `modifytags`, with a single method `Apply`. 
+
+This method applies the struct tag modification of the receiver to all struct
+fields contained within a given node between given start and end positions.
 
 ## Editor integration
 

--- a/main.go
+++ b/main.go
@@ -150,7 +150,10 @@ func parseFlags(args []string) (*config, *modifytags.Modification, error) {
 		quiet:      *flagQuiet,
 	}
 
-	transform := parseTransform(*flagTransform)
+	transform, err := parseTransform(*flagTransform)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	mod := &modifytags.Modification{
 		Clear:                *flagClearTags,
@@ -252,23 +255,23 @@ func (cfg *config) parse() (*ast.File, error) {
 	return parser.ParseFile(cfg.fset, cfg.file, contents, parser.ParseComments)
 }
 
-func parseTransform(input string) modifytags.Transform {
+func parseTransform(input string) (modifytags.Transform, error) {
 	input = strings.ToLower(input)
 	switch input {
-	case "snakecase":
-		return modifytags.SnakeCase
 	case "camelcase":
-		return modifytags.CamelCase
+		return modifytags.CamelCase, nil
 	case "lispcase":
-		return modifytags.LispCase
+		return modifytags.LispCase, nil
 	case "pascalcase":
-		return modifytags.PascalCase
+		return modifytags.PascalCase, nil
 	case "titlecase":
-		return modifytags.TitleCase
+		return modifytags.TitleCase, nil
 	case "keep":
-		return modifytags.Keep
+		return modifytags.Keep, nil
+	case "snakecase":
+		return modifytags.SnakeCase, nil
 	default:
-		return modifytags.NoTransform
+		return modifytags.SnakeCase, fmt.Errorf("invalid transform value")
 	}
 }
 
@@ -558,10 +561,6 @@ func (cfg *config) validate() error {
 
 	if cfg.fieldName != "" && cfg.structName == "" {
 		return errors.New("-field is requiring -struct")
-	}
-
-	if cfg.fset == nil {
-		return errors.New("no file set")
 	}
 
 	return nil

--- a/main_test.go
+++ b/main_test.go
@@ -27,9 +27,9 @@ func TestParseFlags(t *testing.T) {
 	// The flag.CommandLine.Parse() call fails if there are flags re-defined
 	// with the same name. If there are duplicates, parseFlags() will return
 	// an error.
-	_, _, err := parseFlags([]string{"test"})
-	if err != nil {
-		t.Fatal(err)
+	_, _, err := parseFlags([]string{"-struct", "Server", "-add-tags", "json,xml", "-transform", "invalid"})
+	if err == nil || !reflect.DeepEqual("invalid transform value", err.Error()) {
+		t.Fatal("expected error: " + err.Error())
 	}
 }
 

--- a/modifytags/modifytags_test.go
+++ b/modifytags/modifytags_test.go
@@ -28,8 +28,7 @@ func TestApply(t *testing.T) {
 		{
 			file: "all_structs",
 			m: &Modification{
-				Add:       []string{"json"},
-				Transform: SnakeCase,
+				Add: []string{"json"},
 			},
 			start: token.NoPos, // will be set to start of file
 			end:   token.NoPos, // will be set to end of file
@@ -57,7 +56,6 @@ func TestApply(t *testing.T) {
 				AddOptions: map[string][]string{
 					"json": {"omitempty"},
 				},
-				Transform: SnakeCase,
 			},
 			// TODO: use markers in the test content to delineate start and end, rather than hard-coding here.
 			start: token.Pos(50),  // middle of second struct field


### PR DESCRIPTION
Currently, when calling Apply() without providing a Transform value, gomodifytags throws an error "unknown transform option". We should instead have a default value of snakecase, which is consistent with the command line execution of gomodifytags.