### PR TITLE
Remove tag if new tag value is empty.

### DIFF
--- a/modifytags/modifytags.go
+++ b/modifytags/modifytags.go
@@ -101,11 +101,12 @@ func (mod *Modification) rewrite(fset *token.FileSet, node ast.Node, start, end 
 				continue
 			}
 
-			if f.Tag == nil {
-				f.Tag = &ast.BasicLit{}
+			curTag := ""
+			if f.Tag != nil {
+				curTag = f.Tag.Value
 			}
 
-			res, err := mod.processField(fieldName, f.Tag.Value)
+			res, err := mod.processField(fieldName, curTag)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("%s:%d:%d:%s",
 					fset.Position(f.Pos()).Filename,
@@ -115,7 +116,14 @@ func (mod *Modification) rewrite(fset *token.FileSet, node ast.Node, start, end 
 				continue
 			}
 
-			f.Tag.Value = res
+			if res == "" {
+				f.Tag = nil
+			} else {
+				if f.Tag == nil {
+					f.Tag = &ast.BasicLit{}
+				}
+				f.Tag.Value = res
+			}
 		}
 
 		return true

--- a/modifytags/test-fixtures/clear_all_tags.golden
+++ b/modifytags/test-fixtures/clear_all_tags.golden
@@ -1,9 +1,9 @@
 package foo
 
 type foo struct {
-	bar string 
-	t   bool   
-	t   bool   
-	qux string 
-	yoo string 
+	bar string
+	t   bool
+	t   bool
+	qux string
+	yoo string
 }

--- a/modifytags/test-fixtures/remove_some_tags.golden
+++ b/modifytags/test-fixtures/remove_some_tags.golden
@@ -5,5 +5,5 @@ type foo struct {
 	t   bool   `hcl:"t"`
 	t   bool   `hcl:"t,omitempty"`
 	qux string `hcl:"qux,squash,keys"`
-	yoo string 
+	yoo string
 }

--- a/test-fixtures/field_clear_tags.golden
+++ b/test-fixtures/field_clear_tags.golden
@@ -1,7 +1,7 @@
 package foo
 
 type foo struct {
-	bar string 
+	bar string
 	t   bool   `hcl:"t"`
 	t   bool   `hcl:"t,omitempty"`
 	qux string `json:"qux,omitempty" hcl:"qux,squash,keys"`

--- a/test-fixtures/field_remove.golden
+++ b/test-fixtures/field_remove.golden
@@ -1,7 +1,7 @@
 package foo
 
 type foo struct {
-	bar string 
+	bar string
 	baz string `json:"baz"`
 	t   bool   `hcl:"t"`
 }

--- a/test-fixtures/line_add_option.golden
+++ b/test-fixtures/line_add_option.golden
@@ -1,9 +1,9 @@
 package foo
 
 type foo struct {
-	bar    string   `json:"bar,omitempty"`
-	f      bool     
-	t      bool     
+	bar    string `json:"bar,omitempty"`
+	f      bool
+	t      bool
 	Ankara []string `json:"ankara,omitempty"`
 	a      []string `json:"a"`
 }

--- a/test-fixtures/line_add_option_existing.golden
+++ b/test-fixtures/line_add_option_existing.golden
@@ -3,7 +3,7 @@ package foo
 type foo struct {
 	bar       string `json:"bar"`
 	f         bool
-	t         bool      
+	t         bool
 	Ankara    []string  `json:"ankara,omitempty"`
 	timestamp time.Time `json:"@timestamp,omitempty"`
 }

--- a/test-fixtures/line_remove.golden
+++ b/test-fixtures/line_remove.golden
@@ -3,6 +3,6 @@ package foo
 type foo struct {
 	bar string `json:"bar"`
 	t   bool   `hcl:"t"`
-	qux string 
-	yoo string 
+	qux string
+	yoo string
 }

--- a/test-fixtures/struct_clear_tags.golden
+++ b/test-fixtures/struct_clear_tags.golden
@@ -1,9 +1,9 @@
 package foo
 
 type foo struct {
-	bar string 
-	t   bool   
-	t   bool   
-	qux string 
-	yoo string 
+	bar string
+	t   bool
+	t   bool
+	qux string
+	yoo string
 }

--- a/test-fixtures/struct_remove.golden
+++ b/test-fixtures/struct_remove.golden
@@ -1,6 +1,6 @@
 package foo
 
 type foo struct {
-	bar string 
-	t   bool   `hcl:"t"`
+	bar string
+	t   bool `hcl:"t"`
 }


### PR DESCRIPTION
If the new tag value is the empty string,
set the Tag to be nil. Having empty but
non-nil tags causes formatting issues
that leave trailing whitespace.